### PR TITLE
Add bundle param to Session request/reply APIs.

### DIFF
--- a/apps/pfd/pfd.c
+++ b/apps/pfd/pfd.c
@@ -626,9 +626,17 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    rc = ela_session_init(carrier, session_request_callback, NULL);
+    rc = ela_session_init(carrier);
     if (rc < 0) {
         fprintf(stderr, "Can not initialize Carrier session extension (%08X).",
+                ela_get_error());
+        shutdown();
+        return -1;
+    }
+
+    rc = ela_session_set_callback(carrier, NULL, session_request_callback, NULL);
+    if (rc < 0) {
+        fprintf(stderr, "Can not set callbacks (%08X).",
                 ela_get_error());
         shutdown();
         return -1;

--- a/apps/pfd/pfd.c
+++ b/apps/pfd/pfd.c
@@ -214,7 +214,7 @@ static void friend_request(ElaCarrier *w, const char *userid,
 }
 
 // Client only
-static void session_request_complete(ElaSession *ws, int status,
+static void session_request_complete(ElaSession *ws, const char *bundle, int status,
                 const char *reason, const char *sdp, size_t len, void *context)
 {
     const char *state_name[] = {
@@ -284,7 +284,7 @@ static void stream_state_changed(ElaSession *ws, int stream,
 
     if (config->mode == MODE_CLIENT) {
         if (state == ElaStreamState_initialized) {
-            rc = ela_session_request(ws, session_request_complete, NULL);
+            rc = ela_session_request(ws, NULL, session_request_complete, NULL);
             if (rc < 0) {
                 vlogE("Session request to portforwarding server peer failed(%08X)", ela_get_error());
                 delete_session(ws);
@@ -313,7 +313,7 @@ static void stream_state_changed(ElaSession *ws, int stream,
         }
     } else {
         if (state == ElaStreamState_initialized) {
-            rc = ela_session_reply_request(ws, 0, NULL);
+            rc = ela_session_reply_request(ws, NULL, 0, NULL);
             if (rc < 0) {
                 vlogE("Session request from %s, reply failed(%08X)", peer, ela_get_error());
                 free(ela_session_get_userdata(ws));
@@ -337,7 +337,7 @@ static void stream_state_changed(ElaSession *ws, int stream,
 }
 
 // Server and client
-static void session_request_callback(ElaCarrier *w, const char *from,
+static void session_request_callback(ElaCarrier *w, const char *from, const char *bundle,
                                    const char *sdp, size_t len, void *context)
 {
     ElaSession *ws;
@@ -361,7 +361,7 @@ static void session_request_callback(ElaCarrier *w, const char *from,
     if (config->mode == MODE_CLIENT) {
         // Client mode: just refuse the request.
         vlogI("Refuse session request from %s.", from);
-        ela_session_reply_request(ws, -1, "Refuse");
+        ela_session_reply_request(ws, NULL, -1, "Refuse");
         ela_session_close(ws);
         return;
     }
@@ -380,7 +380,7 @@ static void session_request_callback(ElaCarrier *w, const char *from,
     if (user == NULL) {
         // Not in allowed user list. Refuse session request.
         vlogI("Refuse session request from %s.", from);
-        ela_session_reply_request(ws, -1, "Refuse");
+        ela_session_reply_request(ws, NULL, -1, "Refuse");
         ela_session_close(ws);
         return;
     }
@@ -409,7 +409,7 @@ static void session_request_callback(ElaCarrier *w, const char *from,
                     &stream_callbacks, NULL);
     if (rc <= 0) {
         vlogE("Session request from %s, can not add stream(%08X)", from, ela_get_error());
-        ela_session_reply_request(ws, -1, "Error");
+        ela_session_reply_request(ws, NULL, -1, "Error");
         delete_session(ws);
         free(p);
     }

--- a/apps/shell/shell.c
+++ b/apps/shell/shell.c
@@ -1046,11 +1046,12 @@ static void session_init(ElaCarrier *w, int argc, char *argv[])
         return;
     }
 
-    rc = ela_session_init(w, session_request_callback, NULL);
+    rc = ela_session_init(w);
     if (rc < 0) {
         output("Session initialized failed.\n");
     }
     else {
+        ela_session_set_callback(w, NULL, session_request_callback, NULL);
         output("Session initialized successfully.\n");
     }
 }

--- a/apps/speedtest/speedtest.c
+++ b/apps/speedtest/speedtest.c
@@ -661,11 +661,12 @@ static void session_init(ElaCarrier *w)
 {
     int rc;
 
-    rc = ela_session_init(w, session_request_callback, w);
+    rc = ela_session_init(w);
     if (rc < 0) {
         output("Session initialized unsuccessfully.\n");
     }
     else {
+        ela_session_set_callback(w, NULL, session_request_callback, w);
         output("Session initialized successfully.\n");
     }
 }

--- a/apps/speedtest/speedtest.c
+++ b/apps/speedtest/speedtest.c
@@ -410,7 +410,7 @@ static void invite(ElaCarrier *w, int argc, char *argv[])
 {
     int rc;
 
-    if (argc != 2) {
+    if (argc != 3) {
         output("Invalid invocation.\n");
         return;
     }
@@ -455,7 +455,7 @@ static void reply_invite(ElaCarrier *w, int argc, char *argv[])
 }
 
 static void session_request_callback(ElaCarrier *w, const char *from,
-            const char *sdp, size_t len, void *context)
+            const char *bundle, const char *sdp, size_t len, void *context)
 {
     strncpy(session_ctx.remote_sdp, sdp, len);
     session_ctx.remote_sdp[len] = 0;
@@ -472,7 +472,7 @@ static void session_request_callback(ElaCarrier *w, const char *from,
     session_reply_request(w, 1, reply_arg);
 }
 
-static void session_request_complete_callback(ElaSession *ws, int status,
+static void session_request_complete_callback(ElaSession *ws, const char *bundle, int status,
                 const char *reason, const char *sdp, size_t len, void *context)
 {
     int rc;
@@ -731,7 +731,7 @@ static void session_request(ElaCarrier *w)
 {
     int rc;
 
-    rc = ela_session_request(session_ctx.ws,
+    rc = ela_session_request(session_ctx.ws, NULL,
                              session_request_complete_callback, w);
     if (rc < 0) {
         output("session request unsuccessfully.\n");
@@ -751,7 +751,7 @@ static void session_reply_request(ElaCarrier *w, int argc, char *argv[])
     }
 
     if ((strcmp(argv[0], "ok") == 0) && (argc == 1)) {
-        rc = ela_session_reply_request(session_ctx.ws, 0, NULL);
+        rc = ela_session_reply_request(session_ctx.ws, NULL, 0, NULL);
         if (rc < 0) {
             output("response invite unsuccessfully.\n");
         }
@@ -768,7 +768,7 @@ static void session_reply_request(ElaCarrier *w, int argc, char *argv[])
         }
     }
     else if ((strcmp(argv[0], "refuse") == 0) && (argc == 2)) {
-        rc = ela_session_reply_request(session_ctx.ws, 1, argv[2]);
+        rc = ela_session_reply_request(session_ctx.ws, NULL, 1, argv[2]);
         if (rc < 0) {
             output("response invite unsuccessfully.\n");
         }

--- a/src/carrier/ela_carrier.c
+++ b/src/carrier/ela_carrier.c
@@ -1016,6 +1016,8 @@ static void ela_destroy(void *argv)
     if (w->friend_events)
         deref(w->friend_events);
 
+    pthread_mutex_destroy(&w->ext_mutex);
+
     dht_kill(&w->dht);
 }
 
@@ -1161,6 +1163,14 @@ ElaCarrier *ela_new(const ElaOptions *opts,
         free_persistence_data(&data);
         deref(w);
         ela_set_error(rc);
+        return NULL;
+    }
+
+    rc = pthread_mutex_init(&w->ext_mutex, NULL);
+    if (rc) {
+        free_persistence_data(&data);
+        deref(w);
+        ela_set_error(ELA_SYS_ERROR(rc));
         return NULL;
     }
 
@@ -2535,7 +2545,7 @@ int ela_reply_friend_invite(ElaCarrier *w, const char *to,
     size_t _data_len;
 
     if (!w || !to || !*to || (status != 0 && !reason)
-            || (status == 0 && (!data || !len))) {
+            || (data && !len)) {
         ela_set_error(ELA_GENERAL_ERROR(ELAERR_INVALID_ARGS));
         return -1;
     }
@@ -2586,8 +2596,7 @@ int ela_reply_friend_invite(ElaCarrier *w, const char *to,
     elacp_set_status(cp, status);
     if (status)
         elacp_set_reason(cp, reason);
-    else
-        elacp_set_raw_data(cp, data, len);
+    elacp_set_raw_data(cp, data, len);
 
     _data = elacp_encode(cp, &_data_len);
     elacp_free(cp);

--- a/src/carrier/ela_carrier.c
+++ b/src/carrier/ela_carrier.c
@@ -2596,7 +2596,8 @@ int ela_reply_friend_invite(ElaCarrier *w, const char *to,
     elacp_set_status(cp, status);
     if (status)
         elacp_set_reason(cp, reason);
-    elacp_set_raw_data(cp, data, len);
+    if (data)
+        elacp_set_raw_data(cp, data, len);
 
     _data = elacp_encode(cp, &_data_len);
     elacp_free(cp);

--- a/src/carrier/ela_carrier_impl.h
+++ b/src/carrier/ela_carrier_impl.h
@@ -67,6 +67,7 @@ typedef struct FriendEvent {
 } FriendEvent;
 
 struct ElaCarrier {
+    pthread_mutex_t ext_mutex;
     void *session;  // reserved for session.
 
     DHT dht;

--- a/src/carrier/elacp.c
+++ b/src/carrier/elacp.c
@@ -779,7 +779,9 @@ uint8_t *elacp_encode(ElaCP *cp, size_t *encoded_len)
         if (pktirsp->status) {
             str = flatcc_builder_create_string_str(&builder, pktirsp->reason);
             elacp_invitersp_reason_add(&builder, str);
-        } else {
+        }
+
+        if (pktirsp->data) {
             vec = flatbuffers_uint8_vec_create(&builder, pktirsp->data, pktirsp->len);
             elacp_invitersp_data_add(&builder, vec);
         }
@@ -913,7 +915,8 @@ ElaCP *elacp_decode(const uint8_t *data, size_t len)
         pktirsp->status = elacp_invitersp_status(tblirsp);
         if (pktirsp->status)
             pktirsp->reason = elacp_invitersp_reason(tblirsp);
-        else {
+
+        if (elacp_invitersp_data_is_present(tblirsp)) {
             pktirsp->data = vec = elacp_invitersp_data(tblirsp);
             pktirsp->len = flatbuffers_uint8_vec_len(vec);
         }

--- a/src/session/ela_session.h
+++ b/src/session/ela_session.h
@@ -62,6 +62,8 @@ extern "C" {
 
 #define ELA_MAX_USER_DATA_LEN   2048
 
+#define ELA_MAX_BUNDLE_LEN      128
+
 typedef struct ElaSession ElaSession;
 
 /**
@@ -228,6 +230,8 @@ bool ela_session_jni_onload(void *vm, void *reserved);
  * @param
  *      from        [in] The id from who send the message.
  * @param
+ *      bundle      [in] The bundle of this session.
+ * @param
  *      sdp         [in] The remote users SDP. End the null terminal.
  *                       Reference: https://tools.ietf.org/html/rfc4566
  * @param
@@ -236,7 +240,7 @@ bool ela_session_jni_onload(void *vm, void *reserved);
  *      context     [in] The application defined context data.
  */
 typedef void ElaSessionRequestCallback(ElaCarrier *carrier, const char *from,
-        const char *sdp, size_t len, void *context);
+        const char *bundle, const char *sdp, size_t len, void *context);
 
 /**
  * \~English
@@ -275,6 +279,31 @@ int ela_session_init(ElaCarrier *carrier,
  */
 CARRIER_API
 void ela_session_cleanup(ElaCarrier *carrier);
+
+/**
+ * \~English
+ * Set session request callback.
+ *
+ * @param
+ *      carrier     [in] A handle to the carrier node instance.
+ * @param
+ *      bundle_prefix
+ *                  [in] The prefix of bundle.
+ * @param
+ *      callback
+ *                  [in] The callback function to process this request.
+ * @param
+ *      context
+ *                  [in] The application defined context data.
+ *
+ * @return
+ *      If no error occurs, return 0.
+ *      Otherwise, return -1, and a specific error code can be
+ *      retrieved by calling ela_get_error().
+ */
+CARRIER_API
+int ela_session_set_callback(ElaCarrier *carrier, const char *bundle_prefix,
+        ElaSessionRequestCallback *callback, void *context);
 
 /**
  * \~English
@@ -360,6 +389,8 @@ void *ela_session_get_userdata(ElaSession *session);
  * @param
  *      session     [in] A handle to the ElaSession.
  * @param
+ *      bundle      [in] The bundle of this session.
+ * @param
  *      status      [in] The status code of the response.
  *                       0 is success, otherwise is error.
  * @param
@@ -372,8 +403,9 @@ void *ela_session_get_userdata(ElaSession *session);
  * @param
  *      context     [in] The application defined context data.
  */
-typedef void ElaSessionRequestCompleteCallback(ElaSession *session, int status,
-        const char *reason, const char *sdp, size_t len, void *context);
+typedef void ElaSessionRequestCompleteCallback(ElaSession *session,
+        const char *bundle, int status, const char *reason,
+        const char *sdp, size_t len, void *context);
 
 /**
  * \~English
@@ -381,6 +413,8 @@ typedef void ElaSessionRequestCompleteCallback(ElaSession *session, int status,
  *
  * @param
  *      session     [in] A handle to the ElaSession.
+ * @param
+ *      bundle      [in] The bundle of this session.
  * @param
  *      callback    [in] A pointer to ElaSessionRequestCompleteCallback
  *                       function to receive the session response.
@@ -393,7 +427,7 @@ typedef void ElaSessionRequestCompleteCallback(ElaSession *session, int status,
  *      retrieved by calling ela_get_error().
  */
 CARRIER_API
-int ela_session_request(ElaSession *session,
+int ela_session_request(ElaSession *session, const char *bundle,
         ElaSessionRequestCompleteCallback *callback, void *context);
 
 /**
@@ -404,6 +438,8 @@ int ela_session_request(ElaSession *session,
  *
  * @param
  *      session     [in] A handle to the ElaSession.
+ * @param
+ *      bundle      [in] The bundle of this session.
  * @param
  *      status      [in] The status code of the response.
  *                       0 is success, otherwise is error.
@@ -417,8 +453,8 @@ int ela_session_request(ElaSession *session,
  *      retrieved by calling ela_get_error().
  */
 CARRIER_API
-int ela_session_reply_request(ElaSession *session, int status,
-        const char* reason);
+int ela_session_reply_request(ElaSession *session, const char *bundle,
+        int status, const char* reason);
 
 /**
  * \~English

--- a/src/session/ela_session.h
+++ b/src/session/ela_session.h
@@ -251,19 +251,13 @@ typedef void ElaSessionRequestCallback(ElaCarrier *carrier, const char *from,
  *
  * @param
  *      carrier     [in] A handle to the Carrier node instance.
- * @param
- *      callback    [in] A pointer to the application-defined function of type
- *                       ElaSessionRequestCallback.
- * @param
- *      context     [in] The application defined context data.
  *
  * @return
  *      0 on success, or -1 if an error occurred. The specific error code
  *      can be retrieved by calling ela_get_error().
  */
 CARRIER_API
-int ela_session_init(ElaCarrier *carrier,
-                ElaSessionRequestCallback *callback, void *context);
+int ela_session_init(ElaCarrier *carrier);
 
 /**
  * \~English

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -69,11 +69,19 @@ typedef struct IceTransportOptions {
 } IceTransportOptions;
 
 typedef void (*friend_invite_callback)(ElaCarrier *, const char *from,
-                      const char *data, size_t len, void *context);
+              const char *data, size_t len, void *context);
 
 struct ElaCarrier       {
+    pthread_mutex_t         ext_mutex;
     void                    *extension;
     uint8_t                 padding[1]; // the rest fields belong to Carrier self.
+};
+
+struct BundledRequestCallback {
+    list_entry_t            le;
+    ElaSessionRequestCallback *callback;
+    void                    *context;
+    char                    prefix[1];
 };
 
 struct SessionExtension {
@@ -82,8 +90,11 @@ struct SessionExtension {
     friend_invite_callback  friend_invite_cb;
     void                    *friend_invite_context;
 
-    ElaSessionRequestCallback *request_callback;
-    void                    *context;
+    ElaSessionRequestCallback *default_callback;
+    void                    *default_context;
+
+    pthread_rwlock_t        callbacks_lock;
+    list_t                  *callbacks;
 
     ElaTransport            *transport;
 

--- a/tests/api/session/session_channel_test.c
+++ b/tests/api/session/session_channel_test.c
@@ -115,7 +115,7 @@ static CarrierContext carrier_context = {
     .extra = NULL
 };
 
-static void session_request_complete_callback(ElaSession *ws, int status,
+static void session_request_complete_callback(ElaSession *ws, const char *bundle, int status,
                 const char *reason, const char *sdp, size_t len, void *context)
 {
     SessionContext *sctxt = (SessionContext *)context;

--- a/tests/api/session/session_new_test.c
+++ b/tests/api/session/session_new_test.c
@@ -130,7 +130,7 @@ void new_session_with_friend(TestContext *context)
     CU_ASSERT_EQUAL_FATAL(rc, 0);
     CU_ASSERT_TRUE_FATAL(ela_is_friend(wctxt->carrier, robotid));
 
-    rc = ela_session_init(wctxt->carrier, NULL, NULL);
+    rc = ela_session_init(wctxt->carrier);
     CU_ASSERT_EQUAL_FATAL(rc, 0);
 
     sctxt->session = ela_session_new(wctxt->carrier, robotid);
@@ -163,7 +163,7 @@ void new_session_with_stranger(TestContext *context)
     CU_ASSERT_EQUAL_FATAL(rc, 0);
     CU_ASSERT_FALSE_FATAL(ela_is_friend(wctxt->carrier, robotid));
 
-    rc = ela_session_init(wctxt->carrier, NULL, NULL);
+    rc = ela_session_init(wctxt->carrier);
     CU_ASSERT_EQUAL_FATAL(rc, 0);
 
     sctxt->session = ela_session_new(wctxt->carrier, robotid);

--- a/tests/api/session/session_portforwarding_test.c
+++ b/tests/api/session/session_portforwarding_test.c
@@ -111,7 +111,7 @@ static CarrierContext carrier_context = {
 };
 
 static
-void session_request_complete_callback(ElaSession *ws, int status,
+void session_request_complete_callback(ElaSession *ws, const char *bundle, int status,
                 const char *reason, const char *sdp, size_t len, void *context)
 {
     SessionContext *sctxt = (SessionContext *)context;

--- a/tests/api/session/session_request_reply_test.c
+++ b/tests/api/session/session_request_reply_test.c
@@ -239,8 +239,11 @@ static void test_stream_reply_scheme(ElaStreamType stream_type,
     CU_ASSERT_EQUAL_FATAL(rc, 0);
     CU_ASSERT_TRUE_FATAL(ela_is_friend(wctxt->carrier, robotid));
 
-    rc = ela_session_init(wctxt->carrier, sctxt->request_cb, sctxt);
+    rc = ela_session_init(wctxt->carrier);
     CU_ASSERT_EQUAL_FATAL(rc, 0);
+
+    rc = ela_session_set_callback(wctxt->carrier, NULL, sctxt->request_cb, sctxt);
+    TEST_ASSERT_TRUE(rc == 0);
 
     rc = robot_sinit();
     TEST_ASSERT_TRUE(rc > 0);

--- a/tests/api/session/session_request_reply_test.c
+++ b/tests/api/session/session_request_reply_test.c
@@ -105,7 +105,7 @@ static SessionContextExtra session_extra = {
     .robot_peer_id = {0}
 };
 
-static void session_request_callback(ElaCarrier *w, const char *from,
+static void session_request_callback(ElaCarrier *w, const char *from, const char *bundle,
                                     const char *sdp, size_t len, void *context)
 {
     SessionContext *sctxt = (SessionContext *)context;
@@ -122,7 +122,7 @@ static void session_request_callback(ElaCarrier *w, const char *from,
     cond_signal(sctxt->request_cond);
 }
 
-static void session_request_complete_callback(ElaSession *ws, int status,
+static void session_request_complete_callback(ElaSession *ws, const char *bundle, int status,
                 const char *reason, const char *sdp, size_t len, void *context)
 {
     SessionContext *sctxt = (SessionContext *)context;
@@ -276,7 +276,7 @@ static void test_stream_reply_scheme(ElaStreamType stream_type,
     TEST_ASSERT_TRUE(stream_ctxt->state == ElaStreamState_initialized);
     TEST_ASSERT_TRUE(stream_ctxt->state_bits & (1 << ElaStreamState_initialized));
 
-    rc = ela_session_reply_request(sctxt->session, 0, NULL);
+    rc = ela_session_reply_request(sctxt->session, NULL, 0, NULL);
     TEST_ASSERT_TRUE(rc == 0);
 
     cond_wait(stream_ctxt->cond);

--- a/tests/api/session/session_stream_state_test.c
+++ b/tests/api/session/session_stream_state_test.c
@@ -91,7 +91,7 @@ static CarrierContext carrier_context = {
     .extra = NULL
 };
 
-static void session_request_complete_callback(ElaSession *ws, int status,
+static void session_request_complete_callback(ElaSession *ws, const char *bundle, int status,
                 const char *reason, const char *sdp, size_t len, void *context)
 {
     SessionContext *sctxt = (SessionContext *)context;
@@ -249,7 +249,7 @@ void test_stream_state_scheme(int stream_options, TestContext *context,
     rc = check_state_cb(context, ElaStreamState_initialized);
     TEST_ASSERT_TRUE(rc == 0);
 
-    rc = ela_session_request(sctxt->session, sctxt->request_complete_cb, sctxt);
+    rc = ela_session_request(sctxt->session, NULL, sctxt->request_complete_cb, sctxt);
     TEST_ASSERT_TRUE(rc == 0);
 
     cond_wait(stream_ctxt->cond);

--- a/tests/api/session/session_stream_test.c
+++ b/tests/api/session/session_stream_test.c
@@ -112,7 +112,7 @@ static struct CarrierContext carrier_context = {
     .extra = NULL
 };
 
-static void session_request_complete_callback(ElaSession *ws, int status,
+static void session_request_complete_callback(ElaSession *ws, const char *bundle, int status,
                 const char *reason, const char *sdp, size_t len, void *context)
 {
     SessionContext *sctxt = (SessionContext *)context;

--- a/tests/api/session/session_stream_type_test.c
+++ b/tests/api/session/session_stream_type_test.c
@@ -211,7 +211,7 @@ void check_unimplemented_stream_type(ElaStreamType stream_type,
     CU_ASSERT_EQUAL_FATAL(rc, 0);
     CU_ASSERT_TRUE_FATAL(ela_is_friend(wctxt->carrier, robotid));
 
-    rc = ela_session_init(wctxt->carrier, NULL, NULL);
+    rc = ela_session_init(wctxt->carrier);
     CU_ASSERT_EQUAL_FATAL(rc, 0);
 
     sctxt->session = ela_session_new(wctxt->carrier, robotid);

--- a/tests/api/session/session_stream_type_test.c
+++ b/tests/api/session/session_stream_type_test.c
@@ -91,7 +91,7 @@ static CarrierContext carrier_context = {
     .extra = NULL
 };
 
-static void session_request_complete_callback(ElaSession *ws, int status,
+static void session_request_complete_callback(ElaSession *ws, const char *bundle, int status,
                 const char *reason, const char *sdp, size_t len, void *context)
 {
     SessionContext *sctxt = (SessionContext *)context;

--- a/tests/api/session/suites.h
+++ b/tests/api/session/suites.h
@@ -25,6 +25,7 @@
 
 DECL_TESTSUITE(session_new_test)
 DECL_TESTSUITE(session_request_reply_test)
+DECL_TESTSUITE(session_bundle_test)
 DECL_TESTSUITE(session_stream_test)
 DECL_TESTSUITE(session_stream_type_test)
 DECL_TESTSUITE(session_stream_state_test)
@@ -34,6 +35,7 @@ DECL_TESTSUITE(session_portforwarding_test)
 #define DEFINE_SESSION_TESTSUITES \
     DEFINE_TESTSUITE(session_new_test), \
     DEFINE_TESTSUITE(session_request_reply_test), \
+    DEFINE_TESTSUITE(session_bundle_test), \
     DEFINE_TESTSUITE(session_stream_type_test), \
     DEFINE_TESTSUITE(session_stream_state_test), \
     DEFINE_TESTSUITE(session_stream_test), \

--- a/tests/api/test_helper.c
+++ b/tests/api/test_helper.c
@@ -413,7 +413,7 @@ void test_stream_scheme(ElaStreamType stream_type, int stream_options,
     TEST_ASSERT_TRUE(stream_ctxt->state == ElaStreamState_initialized);
     TEST_ASSERT_TRUE(stream_ctxt->state_bits & (1 << ElaStreamState_initialized));
 
-    rc = ela_session_request(sctxt->session, sctxt->request_complete_cb, sctxt);
+    rc = ela_session_request(sctxt->session, NULL, sctxt->request_complete_cb, sctxt);
     TEST_ASSERT_TRUE(rc == 0);
 
     cond_wait(stream_ctxt->cond);

--- a/tests/api/test_helper.c
+++ b/tests/api/test_helper.c
@@ -390,7 +390,7 @@ void test_stream_scheme(ElaStreamType stream_type, int stream_options,
     CU_ASSERT_EQUAL_FATAL(rc, 0);
     CU_ASSERT_TRUE_FATAL(ela_is_friend(wctxt->carrier, robotid));
 
-    rc = ela_session_init(wctxt->carrier, NULL, NULL);
+    rc = ela_session_init(wctxt->carrier);
     CU_ASSERT_EQUAL_FATAL(rc, 0);
 
     rc = robot_sinit();

--- a/tests/robot/cmd.c
+++ b/tests/robot/cmd.c
@@ -63,7 +63,7 @@ static SessionContextExtra session_extra = {
     .test_peer_id = {0}
 };
 
-static void session_request_callback(ElaCarrier *w, const char *from,
+static void session_request_callback(ElaCarrier *w, const char *from, const char *bundle,
                                      const char *sdp, size_t len, void *context)
 {
     SessionContextExtra *extra = ((SessionContext *)context)->extra;
@@ -77,7 +77,7 @@ static void session_request_callback(ElaCarrier *w, const char *from,
     write_ack("srequest received\n");
 }
 
-static void session_request_complete_callback(ElaSession *ws, int status,
+static void session_request_complete_callback(ElaSession *ws, const char *bundle, int status,
                 const char *reason, const char *sdp, size_t len, void *context)
 {
     SessionContext *sctxt = ((TestContext *)context)->session;
@@ -517,7 +517,7 @@ static void srequest(TestContext *context, int argc, char *argv[])
         goto cleanup;
     }
 
-    rc = ela_session_request(sctxt->session, sctxt->request_complete_cb, context);
+    rc = ela_session_request(sctxt->session, NULL, sctxt->request_complete_cb, context);
     if (rc < 0) {
         vlogE("Session request failed: 0x%x", ela_get_error());
         goto cleanup;
@@ -582,7 +582,7 @@ static void sreply(TestContext *context, int argc, char *argv[])
             goto cleanup;
         }
 
-        rc = ela_session_reply_request(sctxt->session, 0, NULL);
+        rc = ela_session_reply_request(sctxt->session, NULL, 0, NULL);
         if (rc < 0) {
             vlogE("Confirm session reqeust failed: 0x%x", ela_get_error());
             goto cleanup;
@@ -622,7 +622,7 @@ static void sreply(TestContext *context, int argc, char *argv[])
         return;
     }
     else if (strcmp(argv[1], "refuse") == 0) {
-        rc = ela_session_reply_request(sctxt->session, 1, "testing");
+        rc = ela_session_reply_request(sctxt->session, NULL, 1, "testing");
         if (rc < 0) {
             vlogE("Refuse session request failed: 0x%x", ela_get_error());
             goto cleanup;
@@ -646,7 +646,7 @@ cleanup:
     }
 
     if (need_sreply_ack && sctxt->session)
-        ela_session_reply_request(sctxt->session, 2, "Error");
+        ela_session_reply_request(sctxt->session, NULL, 2, "Error");
 
     if (sctxt->session) {
         ela_session_close(sctxt->session);


### PR DESCRIPTION
1. Refine ela_session_init() API, remove parameters of callback and context;
2. When calling ela_session_request/reply_request() APIs,  add bundle parameter to transfer user's cookie and to keep consistence of calling request/reply and invoking of callback;
3. Add tests cases;