### PR TITLE
remove expired friend invite request transaction callbacks

### DIFF
--- a/src/carrier/ela_carrier.c
+++ b/src/carrier/ela_carrier.c
@@ -1543,6 +1543,52 @@ redo_events:
 }
 
 static
+void transacted_callback_expire(ElaCarrier *w, TransactedCallback *callback)
+{
+    char friendid[ELA_MAX_ID_LEN + 1];
+    ElaFriendInviteResponseCallback *callback_func;
+    FriendInfo *fi;
+
+    fi = friends_get(w->friends, callback->friend_number);
+    if (!fi)
+        return;
+
+    strcpy(friendid, fi->info.user_info.userid);
+    deref(fi);
+
+    callback_func = (ElaFriendInviteResponseCallback *)callback->callback_func;
+    assert(callback_func);
+
+    callback_func(w, friendid, ELA_STATUS_TIMEOUT, "timeout", NULL, 0,
+                  callback->callback_context);
+}
+
+static void do_transacted_callabcks_check(ElaCarrier *w)
+{
+    hashtable_iterator_t it;
+    struct timeval now;
+
+    gettimeofday(&now, NULL);
+
+    transacted_callbacks_iterate(w->tcallbacks, &it);
+    while(transacted_callbacks_iterator_has_next(&it)) {
+        TransactedCallback *tcb;
+        int rc;
+
+        rc = transacted_callbacks_iterator_next(&it, &tcb);
+        if (rc <= 0)
+            break;
+
+        if (timercmp(&now, &tcb->expire_time, >)) {
+            hashtable_iterator_remove(&it);
+            transacted_callback_expire(w, tcb);
+        }
+
+        deref(tcb);
+    }
+}
+
+static
 void handle_friend_message(ElaCarrier *w, uint32_t friend_number, ElaCP *cp)
 {
     FriendInfo *fi;
@@ -1781,11 +1827,10 @@ int ela_run(ElaCarrier *w, int interval)
         timeradd(&expire, &tmp, &expire);
 
         do_friend_events(w);
+        do_transacted_callabcks_check(w);
 
         if (idle_interval > 0)
             notify_idle(w);
-
-        // TODO: Check connection:.
 
         gettimeofday(&check, NULL);
 
@@ -2515,6 +2560,7 @@ int ela_invite_friend(ElaCarrier *w, const char *to,
     }
 
     tcb->tid = tid;
+    tcb->friend_number = friend_number;
     tcb->callback_func = callback;
     tcb->callback_context = context;
 
@@ -2525,6 +2571,7 @@ int ela_invite_friend(ElaCarrier *w, const char *to,
     free(_data);
 
     if (rc < 0) {
+        transacted_callbacks_remove(w->tcallbacks, tid);
         ela_set_error(rc);
         return -1;
     }

--- a/src/carrier/ela_carrier.h
+++ b/src/carrier/ela_carrier.h
@@ -122,6 +122,16 @@ extern "C" {
  */
 #define ELA_MAX_APP_MESSAGE_LEN         1024
 
+/**
+ * \~English
+ * System reserved reply reason.
+ */
+#define ELA_STATUS_TIMEOUT              1
+
+/**
+ * \~English
+ * ElaCarrier representing carrier node singleton instance.
+ */
 typedef struct ElaCarrier ElaCarrier;
 
 /******************************************************************************

--- a/src/carrier/ela_carrier_impl.h
+++ b/src/carrier/ela_carrier_impl.h
@@ -111,18 +111,6 @@ typedef struct SessionExtension {
     uint8_t                 reserved[1];
 } SessionExtension;
 
-typedef struct FriendLabelItem {
-    uint32_t friend_number;
-    char *label;
-} FriendLabelItem;
-
-typedef struct TransactedCallback {
-    hash_entry_t he;
-    int64_t tid;
-    void *callback_func;
-    void *callback_context;
-} TransactedCallback;
-
 CARRIER_API
 void ela_set_error(int error);
 

--- a/src/carrier/tcallbacks.h
+++ b/src/carrier/tcallbacks.h
@@ -28,7 +28,16 @@
 
 #include <linkedhashtable.h>
 
-#include "ela_carrier_impl.h"
+#define TRANSACTION_EXPIRE_INTERVAL     (5 * 60) // 5m
+
+typedef struct TransactedCallback {
+    hash_entry_t he;
+    int64_t tid;
+    uint32_t friend_number;
+    void *callback_func;
+    void *callback_context;
+    struct timeval expire_time;
+} TransactedCallback;
 
 static
 uint32_t cid_hash_code(const void *key, size_t keylen)
@@ -80,10 +89,18 @@ static inline
 void transacted_callbacks_put(hashtable_t *callbacks,
                               TransactedCallback *callback)
 {
+    struct timeval now, interval;
+
     assert(callbacks && callback);
     callback->he.data = callback;
     callback->he.key = &callback->tid;
     callback->he.keylen = sizeof(callback->tid);
+
+    gettimeofday(&now, NULL);
+    interval.tv_sec = TRANSACTION_EXPIRE_INTERVAL;
+    interval.tv_usec = 0;
+    timeradd(&now, &interval, &callback->expire_time);
+
     hashtable_put(callbacks, &callback->he);
 }
 
@@ -106,6 +123,36 @@ void transacted_callbacks_clear(hashtable_t *callbacks)
 {
     assert(callbacks);
     hashtable_clear(callbacks);
+}
+
+static inline
+hashtable_iterator_t *transacted_callbacks_iterate(hashtable_t *friends,
+                                           hashtable_iterator_t *iterator)
+{
+    assert(friends && iterator);
+    return hashtable_iterate(friends, iterator);
+}
+
+static inline
+int transacted_callbacks_iterator_next(hashtable_iterator_t *iterator,
+                                      TransactedCallback **callback)
+{
+    assert(iterator && callback);
+    return hashtable_iterator_next(iterator, NULL, NULL, (void **)callback);
+}
+
+static inline
+int transacted_callbacks_iterator_has_next(hashtable_iterator_t *iterator)
+{
+    assert(iterator);
+    return hashtable_iterator_has_next(iterator);
+}
+
+static inline
+void transacted_callbacks_iterator_remove(hashtable_iterator_t *iterator)
+{
+    assert(iterator);
+    hashtable_iterator_remove(iterator);
 }
 
 #endif /* __TCALLBACKS_H__ */


### PR DESCRIPTION
1. To inviter,  friend invite transacted callbacks will be removed after expired timeout 5 minutes; 
2. To receiver, when it received friend invitation, it is app's responsibility to call  ela_friend_reply_invite() API to reply that invitation as soon as possible, to remove transaction history item and avoid memory leakage.