### PR TITLE
Fix "loading configure failed" error

### DIFF
--- a/apps/shell/elashell.sh
+++ b/apps/shell/elashell.sh
@@ -4,6 +4,7 @@ DATA_DIR=~/.elashell
 
 SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
 SCRIPT_DIRNAME="$(basename "${SCRIPT_PATH}")"
+CONFIG_FILE="$(dirname "${SCRIPT_PATH}")/etc/carrier/elashell.conf"
 
 # Running in installation or dist directory
 LDPATH="$(dirname "${SCRIPT_PATH}")/lib"
@@ -29,4 +30,4 @@ esac
 
 export ${DSO_ENV}=${LDPATH}
 
-cd ${SCRIPT_PATH} && ./elashell $*
+${SCRIPT_PATH}/elashell -c ${CONFIG_FILE} $*


### PR DESCRIPTION
When executing elashell.sh , the following error was shown in command line:
(null):0 - file I/O error
loading configure failed !

The apps/shell/elashell.sh file was missing the CONFIG_FILE variable.

