### PR TITLE
enhance elatests add/remove friend procedure

### DIFF
--- a/tests/api/carrier/friend_label_test.c
+++ b/tests/api/carrier/friend_label_test.c
@@ -54,8 +54,9 @@ static void friend_connection_cb(ElaCarrier *w, const char *friendid,
 {
     CarrierContext *wctxt = (CarrierContext *)context;
 
-    wakeup(context);
-    wctxt->robot_online = (status == ElaConnectionStatus_Connected);
+    wctxt->friend_status = (status == ElaConnectionStatus_Connected) ?
+                         ONLINE : OFFLINE;
+    cond_signal(wctxt->friend_status_cond);
 
     vlogD("Robot connection status changed -> %s", connection_str(status));
 }
@@ -78,12 +79,14 @@ static ElaCallbacks callbacks = {
 
 static Condition DEFINE_COND(ready_cond);
 static Condition DEFINE_COND(cond);
+static Condition DEFINE_COND(friend_status_cond);
 
 static CarrierContext carrier_context = {
     .cbs = &callbacks,
     .carrier = NULL,
     .ready_cond = &ready_cond,
     .cond = &cond,
+    .friend_status_cond = &friend_status_cond,
     .extra = NULL
 };
 

--- a/tests/api/carrier/friend_message_test.c
+++ b/tests/api/carrier/friend_message_test.c
@@ -69,8 +69,9 @@ static void friend_connection_cb(ElaCarrier *w, const char *friendid,
 {
     CarrierContext *wctxt = (CarrierContext *)context;
 
-    wakeup(context);
-    wctxt->robot_online = (status == ElaConnectionStatus_Connected);
+    wctxt->friend_status = (status == ElaConnectionStatus_Connected) ?
+                         ONLINE : OFFLINE;
+    cond_signal(wctxt->friend_status_cond);
 
     vlogD("Robot connection status changed -> %s", connection_str(status));
 }
@@ -105,12 +106,14 @@ static ElaCallbacks callbacks = {
 
 static Condition DEFINE_COND(ready_cond);
 static Condition DEFINE_COND(cond);
+static Condition DEFINE_COND(friend_status_cond);
 
 static CarrierContext carrier_context = {
     .cbs = &callbacks,
     .carrier = NULL,
     .ready_cond = &ready_cond,
     .cond = &cond,
+    .friend_status_cond = &friend_status_cond,
     .extra = &extra
 };
 
@@ -235,11 +238,6 @@ int friend_message_test_suite_init(void)
     if (rc < 0) {
         CU_FAIL("Error: test suite initialize error");
         return -1;
-    }
-
-    if (ela_is_friend(test_context.carrier->carrier, robotid)) {
-        // wait for robot online.
-        cond_wait(test_context.carrier->cond);
     }
 
     return 0;

--- a/tests/api/carrier/get_id_test.c
+++ b/tests/api/carrier/get_id_test.c
@@ -54,12 +54,14 @@ static ElaCallbacks callbacks = {
 
 static Condition DEFINE_COND(ready_cond);
 static Condition DEFINE_COND(cond);
+static Condition DEFINE_COND(friend_status_cond);
 
 static CarrierContext carrier_context = {
     .cbs = &callbacks,
     .carrier = NULL,
     .ready_cond = &ready_cond,
     .cond = &cond,
+    .friend_status_cond = &friend_status_cond,
     .extra = NULL
 };
 

--- a/tests/api/carrier/get_info_test.c
+++ b/tests/api/carrier/get_info_test.c
@@ -52,12 +52,14 @@ static ElaCallbacks callbacks = {
 
 static Condition DEFINE_COND(ready_cond);
 static Condition DEFINE_COND(cond);
+static Condition DEFINE_COND(friend_status_cond);
 
 static CarrierContext carrier_context = {
     .cbs = &callbacks,
     .carrier = NULL,
     .ready_cond = &ready_cond,
     .cond = &cond,
+    .friend_status_cond = &friend_status_cond,
     .extra = NULL
 };
 

--- a/tests/api/carrier/node_login_test.c
+++ b/tests/api/carrier/node_login_test.c
@@ -34,12 +34,14 @@ static ElaCallbacks callbacks = {
 };
 
 static Condition DEFINE_COND(ready_cond);
+static Condition DEFINE_COND(friend_status_cond);
 
 static CarrierContext carrier_context = {
     .cbs = &callbacks,
     .carrier = NULL,
     .ready_cond = &ready_cond,
     .cond = NULL,
+    .friend_status_cond = &friend_status_cond,
     .extra = NULL
 };
 

--- a/tests/api/session/session_bundle_test.c
+++ b/tests/api/session/session_bundle_test.c
@@ -59,8 +59,9 @@ static void friend_connection_cb(ElaCarrier *w, const char *friendid,
 {
     CarrierContext *wctxt = (CarrierContext *)context;
 
-    wakeup(context);
-    wctxt->robot_online = (status == ElaConnectionStatus_Connected);
+    wctxt->friend_status = (status == ElaConnectionStatus_Connected) ?
+                         ONLINE : OFFLINE;
+    cond_signal(wctxt->friend_status_cond);
 
     vlogD("Robot connection status changed -> %s", connection_str(status));
 }
@@ -83,13 +84,14 @@ static ElaCallbacks callbacks = {
 
 static Condition DEFINE_COND(carrier_ready_cond);
 static Condition DEFINE_COND(carrier_cond);
+static Condition DEFINE_COND(friend_status_cond);
 
 static CarrierContext carrier_context = {
     .cbs = &callbacks,
     .carrier = NULL,
-    .robot_online = false,
     .ready_cond = &carrier_ready_cond,
     .cond = &carrier_cond,
+    .friend_status_cond = &friend_status_cond,
     .extra = NULL
 };
 

--- a/tests/api/session/session_channel_test.c
+++ b/tests/api/session/session_channel_test.c
@@ -82,8 +82,9 @@ static void friend_connection_cb(ElaCarrier *w, const char *friendid,
 {
     CarrierContext *wctxt = (CarrierContext *)context;
 
-    wakeup(context);
-    wctxt->robot_online = (status == ElaConnectionStatus_Connected);
+    wctxt->friend_status = (status == ElaConnectionStatus_Connected) ?
+                         ONLINE : OFFLINE;
+    cond_signal(wctxt->friend_status_cond);
 
     vlogD("Robot connection status changed -> %s", connection_str(status));
 }
@@ -106,12 +107,14 @@ static ElaCallbacks callbacks = {
 
 static Condition DEFINE_COND(carrier_ready_cond);
 static Condition DEFINE_COND(carrier_cond);
+static Condition DEFINE_COND(friend_status_cond);
 
 static CarrierContext carrier_context = {
     .cbs = &callbacks,
     .carrier = NULL,
     .ready_cond = &carrier_ready_cond,
     .cond = &carrier_cond,
+    .friend_status_cond = &friend_status_cond,
     .extra = NULL
 };
 

--- a/tests/api/session/session_new_test.c
+++ b/tests/api/session/session_new_test.c
@@ -58,8 +58,9 @@ static void friend_connection_cb(ElaCarrier *w, const char *friendid,
 {
     CarrierContext *wctxt = (CarrierContext *)context;
 
-    wakeup(context);
-    wctxt->robot_online = (status == ElaConnectionStatus_Connected);
+    wctxt->friend_status = (status == ElaConnectionStatus_Connected) ?
+                         ONLINE : OFFLINE;
+    cond_signal(wctxt->friend_status_cond);
 
     vlogD("Robot connection status changed -> %s", connection_str(status));
 }
@@ -82,12 +83,14 @@ static ElaCallbacks callbacks = {
 
 static Condition DEFINE_COND(carrier_ready_cond);
 static Condition DEFINE_COND(carrier_cond);
+static Condition DEFINE_COND(friend_status_cond);
 
 static CarrierContext carrier_context = {
     .cbs = &callbacks,
     .carrier = NULL,
     .ready_cond = &carrier_ready_cond,
     .cond = &carrier_cond,
+    .friend_status_cond = &friend_status_cond,
     .extra = NULL,
 };
 

--- a/tests/api/session/session_portforwarding_test.c
+++ b/tests/api/session/session_portforwarding_test.c
@@ -77,8 +77,9 @@ static void friend_connection_cb(ElaCarrier *w, const char *friendid,
 {
     CarrierContext *wctxt = (CarrierContext *)context;
 
-    wakeup(context);
-    wctxt->robot_online = (status == ElaConnectionStatus_Connected);
+    wctxt->friend_status = (status == ElaConnectionStatus_Connected) ?
+                         ONLINE : OFFLINE;
+    cond_signal(wctxt->friend_status_cond);
 
     vlogD("Robot node connection status changed -> %s", connection_str(status));
 }
@@ -101,12 +102,14 @@ static ElaCallbacks callbacks = {
 
 static Condition DEFINE_COND(carrier_ready_cond);
 static Condition DEFINE_COND(carrier_cond);
+static Condition DEFINE_COND(friend_status_cond);
 
 static CarrierContext carrier_context = {
     .cbs = &callbacks,
     .carrier = NULL,
     .ready_cond = &carrier_ready_cond,
     .cond = &carrier_cond,
+    .friend_status_cond = &friend_status_cond,
     .extra = NULL
 };
 

--- a/tests/api/session/session_request_reply_test.c
+++ b/tests/api/session/session_request_reply_test.c
@@ -59,8 +59,9 @@ static void friend_connection_cb(ElaCarrier *w, const char *friendid,
 {
     CarrierContext *wctxt = (CarrierContext *)context;
 
-    wakeup(context);
-    wctxt->robot_online = (status == ElaConnectionStatus_Connected);
+    wctxt->friend_status = (status == ElaConnectionStatus_Connected) ?
+                         ONLINE : OFFLINE;
+    cond_signal(wctxt->friend_status_cond);
 
     vlogD("Robot connection status changed -> %s", connection_str(status));
 }
@@ -83,13 +84,14 @@ static ElaCallbacks callbacks = {
 
 static Condition DEFINE_COND(carrier_ready_cond);
 static Condition DEFINE_COND(carrier_cond);
+static Condition DEFINE_COND(friend_status_cond);
 
 static CarrierContext carrier_context = {
     .cbs = &callbacks,
     .carrier = NULL,
-    .robot_online = false,
     .ready_cond = &carrier_ready_cond,
     .cond = &carrier_cond,
+    .friend_status_cond = &friend_status_cond,
     .extra = NULL
 };
 

--- a/tests/api/session/session_stream_state_test.c
+++ b/tests/api/session/session_stream_state_test.c
@@ -58,8 +58,9 @@ static void friend_connection_cb(ElaCarrier *w, const char *friendid,
 {
     CarrierContext *wctxt = (CarrierContext *)context;
 
-    wakeup(context);
-    wctxt->robot_online = (status == ElaConnectionStatus_Connected);
+    wctxt->friend_status = (status == ElaConnectionStatus_Connected) ?
+                         ONLINE : OFFLINE;
+    cond_signal(wctxt->friend_status_cond);
 
     vlogD("Robot connection status changed -> %s", connection_str(status));
 }
@@ -82,12 +83,14 @@ static ElaCallbacks callbacks = {
 
 static Condition DEFINE_COND(carrier_ready_cond);
 static Condition DEFINE_COND(carrier_cond);
+static Condition DEFINE_COND(friend_status_cond);
 
 static CarrierContext carrier_context = {
     .cbs = &callbacks,
     .carrier = NULL,
     .ready_cond = &carrier_ready_cond,
     .cond = &carrier_cond,
+    .friend_status_cond = &friend_status_cond,
     .extra = NULL
 };
 

--- a/tests/api/session/session_stream_test.c
+++ b/tests/api/session/session_stream_test.c
@@ -79,8 +79,9 @@ static void friend_connection_cb(ElaCarrier *w, const char *friendid,
 {
     CarrierContext *wctxt = (CarrierContext *)context;
 
-    wakeup(context);
-    wctxt->robot_online = (status == ElaConnectionStatus_Connected);
+    wctxt->friend_status = (status == ElaConnectionStatus_Connected) ?
+                         ONLINE : OFFLINE;
+    cond_signal(wctxt->friend_status_cond);
 
     vlogD("Robot connection status changed -> %s", connection_str(status));
 }
@@ -103,12 +104,14 @@ static ElaCallbacks callbacks = {
 
 static Condition DEFINE_COND(carrier_ready_cond);
 static Condition DEFINE_COND(carrier_cond);
+static Condition DEFINE_COND(friend_status_cond);
 
 static struct CarrierContext carrier_context = {
     .cbs = &callbacks,
     .carrier = NULL,
     .ready_cond = &carrier_ready_cond,
     .cond = &carrier_cond,
+    .friend_status_cond = &friend_status_cond,
     .extra = NULL
 };
 

--- a/tests/api/session/session_stream_type_test.c
+++ b/tests/api/session/session_stream_type_test.c
@@ -58,8 +58,9 @@ static void friend_connection_cb(ElaCarrier *w, const char *friendid,
 {
     CarrierContext *wctxt = (CarrierContext *)context;
 
-    wakeup(context);
-    wctxt->robot_online = (status == ElaConnectionStatus_Connected);
+    wctxt->friend_status = (status == ElaConnectionStatus_Connected) ?
+                         ONLINE : OFFLINE;
+    cond_signal(wctxt->friend_status_cond);
 
     vlogD("Robot connection status changed -> %s", connection_str(status));
 }
@@ -82,12 +83,14 @@ static ElaCallbacks callbacks = {
 
 static Condition DEFINE_COND(carrier_ready_cond);
 static Condition DEFINE_COND(carrier_cond);
+static Condition DEFINE_COND(friend_status_cond);
 
 static CarrierContext carrier_context = {
     .cbs = &callbacks,
     .carrier = NULL,
     .ready_cond = &carrier_ready_cond,
     .cond = &carrier_cond,
+    .friend_status_cond = &friend_status_cond,
     .extra = NULL
 };
 

--- a/tests/include/test_context.h
+++ b/tests/include/test_context.h
@@ -62,9 +62,19 @@ typedef struct CarrierContext {
     ElaCarrier *carrier;
     Condition *ready_cond;
     Condition *cond;
+    Condition *friend_status_cond;
     pthread_t thread;
-    bool robot_online;
-    bool fadd_in_progress; // exclusive on robot
+    /**
+     * the sufficient and necessary condition of friend_status being "online" is:
+     * 1. we are connected to carrier network
+     * 2. peer is a friend of ours
+     * 3. we received peer online notification
+     */
+    enum {
+       OFFLINE,
+       ONLINE,
+       FAILED
+    } friend_status;
 
     CarrierContextExtra *extra;
 } CarrierContext;

--- a/tests/robot/cmd.h
+++ b/tests/robot/cmd.h
@@ -37,6 +37,7 @@ int start_cmd_listener(const char *host, const char *port);
 void stop_cmd_listener(void);
 char *read_cmd(void);
 void do_cmd(TestContext*, char*);
+void faccept(TestContext *context, int argc, char *argv[]);
 
 int write_ack(const char *what, ...);
 


### PR DESCRIPTION
1. no matter what relationship between elatest and robot is before calling add_friend_anyway(), it’s ensured both are friend to each other and see each other online when the call returns.
2. no matter what relationship between elatest and robot is before calling remove_friend_anyway(), it’s ensured both are no longer friend to each other and see each other offline when the call returns.
3. it’s safe to excute fadd/faccept/fremove command on robot no matter in what relationship with elatest the robot is on robot’s perspective.