### PR TITLE
Add an optional bundle and corresponding test cases.

### DIFF
--- a/apps/speedtest/speedtest.c
+++ b/apps/speedtest/speedtest.c
@@ -380,11 +380,13 @@ static void send_message(ElaCarrier *w, int argc, char *argv[])
         output("Send message unsuccessfully(0x%x).\n", ela_get_error());
 }
 
-static void invite_response_callback(ElaCarrier *w, const char *friendid,
+static void invite_response_callback(ElaCarrier *w, const char *friendid, const char *bundle,
                                      int status, const char *reason,
                                      const void *data, size_t len, void *context)
 {
-    output("Got invite response from %s. ", friendid);
+    output("Got invite response from %s with bundle: %s\n", friendid,
+            bundle ? bundle : "N/A");
+
     if (status == 0) {
         char *new_arg[1] = {NULL};
         char *add_stream_arg[2] = {NULL, NULL};
@@ -415,7 +417,7 @@ static void invite(ElaCarrier *w, int argc, char *argv[])
         return;
     }
 
-    rc = ela_invite_friend(w, argv[0], argv[1], strlen(argv[1]),
+    rc = ela_invite_friend(w, argv[0], NULL, argv[1], strlen(argv[1]),
                                invite_response_callback, NULL);
     if (rc == 0)
         output("Send invite request successfully.\n");
@@ -447,7 +449,7 @@ static void reply_invite(ElaCarrier *w, int argc, char *argv[])
         return;
     }
 
-    rc = ela_reply_friend_invite(w, argv[0], status, reason, msg, msg_len);
+    rc = ela_reply_friend_invite(w, argv[0], NULL, status, reason, msg, msg_len);
     if (rc == 0)
         output("Send invite reply to inviter successfully.\n");
     else
@@ -1040,7 +1042,7 @@ static void message_callback(ElaCarrier *w, const char *from,
     }
 }
 
-static void invite_request_callback(ElaCarrier *w, const char *from,
+static void invite_request_callback(ElaCarrier *w, const char *from, const char *bundle,
                                     const void *data, size_t len, void *context)
 {
     char *new_arg[1] = {NULL};

--- a/src/carrier/ela_carrier.h
+++ b/src/carrier/ela_carrier.h
@@ -130,13 +130,19 @@ extern "C" {
 
 /**
  * \~English
- * Carrier invite request/reply max transmission length.
+ * Carrier invite/reply max data length.
  */
 #define ELA_MAX_INVITE_DATA_LEN         8192
 
 /**
  * \~English
- * Carrier Invite reply max reason length.
+ * Carrier invite/reply max bundle length.
+ */
+#define ELA_MAX_BUNDLE_LEN              511
+
+/**
+ * \~English
+ * Carrier invite reply max reason length.
  */
 #define ELA_MAX_INVITE_REPLY_REASON_LEN 255
 
@@ -738,6 +744,8 @@ typedef struct ElaCallbacks {
      * @param
      *      from        [in] The user id from who send the invite request.
      * @param
+     *      bundle      [in] The bundle attached to this invite request.
+     * @param
      *      data        [in] The application defined data send from friend.
      * @param
      *      len         [in] The data length in bytes.
@@ -745,6 +753,7 @@ typedef struct ElaCallbacks {
      *      context     [in] The application defined context data.
      */
     void (*friend_invite)(ElaCarrier *carrier, const char *from,
+                          const char *bundle,
                           const void *data, size_t len, void *context);
 
     /**
@@ -1294,6 +1303,8 @@ int ela_send_friend_message(ElaCarrier *carrier, const char *to,
  * @param
  *      from        [in] The target user id.
  * @param
+ *      bundle      [in] The bundle attached to this invite reply.
+ * @param
  *      status      [in] The status code of the response.
  *                       0 is success, otherwise is error.
  * @param
@@ -1307,6 +1318,7 @@ int ela_send_friend_message(ElaCarrier *carrier, const char *to,
  */
 typedef void ElaFriendInviteResponseCallback(ElaCarrier *carrier,
                                              const char *from,
+                                             const char *bundle,
                                              int status, const char *reason,
                                              const void *data, size_t len,
                                              void *context);
@@ -1323,6 +1335,8 @@ typedef void ElaFriendInviteResponseCallback(ElaCarrier *carrier,
  * @param
  *      to          [in] The target userid.
  * @param
+ *      bundle      [in] The bundle attached to this invitation.
+ * @param
  *      data        [in] The application defined data send to target user.
  * @param
  *      len         [in] The data length in bytes.
@@ -1338,7 +1352,7 @@ typedef void ElaFriendInviteResponseCallback(ElaCarrier *carrier,
  *      retrieved by calling ela_get_error().
  */
 CARRIER_API
-int ela_invite_friend(ElaCarrier *carrier, const char *to,
+int ela_invite_friend(ElaCarrier *carrier, const char *to, const char *bundle,
                       const void *data, size_t len,
                       ElaFriendInviteResponseCallback *callback,
                       void *context);
@@ -1353,6 +1367,8 @@ int ela_invite_friend(ElaCarrier *carrier, const char *to,
  *      carrier     [in] A handle to the Carrier node instance.
  * @param
  *      to          [in] The userid who send invite request.
+ * @param
+ *      bundle      [in] The bundle attached to this invitation reply.
  * @param
  *      status      [in] The status code of the response.
  *                       0 is success, otherwise is error.
@@ -1373,6 +1389,7 @@ int ela_invite_friend(ElaCarrier *carrier, const char *to,
  */
 CARRIER_API
 int ela_reply_friend_invite(ElaCarrier *carrier, const char *to,
+                            const char *bundle,
                             int status, const char *reason,
                             const void *data, size_t len);
 

--- a/src/carrier/ela_carrier_impl.h
+++ b/src/carrier/ela_carrier_impl.h
@@ -107,7 +107,7 @@ struct ElaCarrier {
 };
 
 typedef void (*friend_invite_callback)(ElaCarrier *, const char *,
-                                       const char *, size_t, void *);
+                                       const char *, const void *, size_t, void *);
 typedef struct SessionExtension {
     ElaCarrier              *carrier;
 

--- a/src/carrier/elacp.c
+++ b/src/carrier/elacp.c
@@ -67,6 +67,7 @@ struct ElaCPFriendMsg {
 struct ElaCPInviteReq {
     ElaCP header;
     int64_t tid;
+    const char *bundle;
     size_t totalsz;
     size_t len;
     const uint8_t *data;
@@ -75,6 +76,7 @@ struct ElaCPInviteReq {
 struct ElaCPInviteRsp {
     ElaCP header;
     int64_t tid;
+    const char *bundle;
     size_t totalsz;
     int status;
     const char *reason;
@@ -457,6 +459,29 @@ size_t elacp_get_raw_data_length(ElaCP *cp)
     return len;
 }
 
+const char *elacp_get_bundle(ElaCP *cp)
+{
+     struct elacp_packet_t pkt;
+     const char *bundle = NULL;
+
+     assert(cp);
+     pkt.u.cp = cp;
+
+     switch(cp->type) {
+     case ELACP_TYPE_INVITE_REQUEST:
+         bundle = pktireq->bundle;
+         break;
+     case ELACP_TYPE_INVITE_RESPONSE:
+         bundle = pktirsp->bundle;
+         break;
+     default:
+         assert(0);
+         break;
+     }
+
+     return bundle;
+ }
+
 const char *elacp_get_reason(ElaCP *cp)
 {
     struct elacp_packet_t pkt;
@@ -722,6 +747,26 @@ void elacp_set_raw_data(ElaCP *cp, const void *data, size_t len)
     }
 }
 
+void elacp_set_bundle(ElaCP *cp, const char *bundle)
+ {
+     struct elacp_packet_t pkt;
+     assert(cp);
+
+     pkt.u.cp = cp;
+
+     switch(cp->type) {
+     case ELACP_TYPE_INVITE_REQUEST:
+         pktireq->bundle = bundle;
+         break;
+     case ELACP_TYPE_INVITE_RESPONSE:
+         pktirsp->bundle = bundle;
+         break;
+     default:
+         assert(0);
+         break;
+     }
+}
+
 void elacp_set_reason(ElaCP *cp, const char *reason)
 {
     struct elacp_packet_t pkt;
@@ -810,6 +855,10 @@ uint8_t *elacp_encode(ElaCP *cp, size_t *encoded_len)
         }
         elacp_invitereq_tid_add(&builder, pktireq->tid);
         elacp_invitereq_totalsz_add(&builder, pktireq->totalsz);
+        if (pktireq->bundle) {
+             str = flatcc_builder_create_string_str(&builder, pktireq->bundle);
+             elacp_invitereq_bundle_add(&builder, str);
+        }
         vec = flatbuffers_uint8_vec_create(&builder, pktireq->data, pktireq->len);
         elacp_invitereq_data_add(&builder, vec);
         ref = elacp_invitereq_end(&builder);
@@ -823,13 +872,15 @@ uint8_t *elacp_encode(ElaCP *cp, size_t *encoded_len)
         }
         elacp_invitersp_tid_add(&builder, pktirsp->tid);
         elacp_invitersp_totalsz_add(&builder, pktirsp->totalsz);
+        if (pktirsp->bundle) {
+             str = flatcc_builder_create_string_str(&builder, pktirsp->bundle);
+             elacp_invitersp_bundle_add(&builder, str);
+        }
         elacp_invitersp_status_add(&builder, pktirsp->status);
         if (pktirsp->status && pktirsp->reason) {
             str = flatcc_builder_create_string_str(&builder, pktirsp->reason);
             elacp_invitersp_reason_add(&builder, str);
-        }
-
-        if (pktirsp->data) {
+        } else {
             vec = flatbuffers_uint8_vec_create(&builder, pktirsp->data, pktirsp->len);
             elacp_invitersp_data_add(&builder, vec);
         }
@@ -952,6 +1003,8 @@ ElaCP *elacp_decode(const uint8_t *data, size_t len)
         tblireq = elacp_packet_body(packet);
         pktireq->tid = elacp_invitereq_tid(tblireq);
         pktireq->totalsz = elacp_invitereq_totalsz(tblireq);
+        if (elacp_invitereq_bundle_is_present(tblireq))
+             pktireq->bundle = elacp_invitereq_bundle(tblireq);
         pktireq->data = vec = elacp_invitereq_data(tblireq);
         pktireq->len = flatbuffers_uint8_vec_len(vec);
         if (elacp_invitereq_ext_is_present(tblireq))
@@ -962,11 +1015,12 @@ ElaCP *elacp_decode(const uint8_t *data, size_t len)
         tblirsp = elacp_packet_body(packet);
         pktirsp->tid = elacp_invitersp_tid(tblirsp);
         pktireq->totalsz = elacp_invitersp_totalsz(tblirsp);
+        if (elacp_invitersp_bundle_is_present(tblirsp))
+             pktirsp->bundle = elacp_invitersp_bundle(tblirsp);
         pktirsp->status = elacp_invitersp_status(tblirsp);
         if (pktirsp->status)
             pktirsp->reason = elacp_invitersp_reason(tblirsp);
-
-        if (elacp_invitersp_data_is_present(tblirsp)) {
+        else {
             pktirsp->data = vec = elacp_invitersp_data(tblirsp);
             pktirsp->len = flatbuffers_uint8_vec_len(vec);
         }

--- a/src/carrier/elacp.fbs
+++ b/src/carrier/elacp.fbs
@@ -46,6 +46,7 @@ table friendmsg {
 table invitereq {
     ext    : string;
     tid    : long;
+    bundle : string;
     totalsz: uint;
     data   : [uint8];
 }
@@ -53,6 +54,7 @@ table invitereq {
 table invitersp {
     ext    : string;
     tid    : long;
+    bundle : string;
     totalsz: uint;
     status : int;
     reason : string;

--- a/src/carrier/elacp.h
+++ b/src/carrier/elacp.h
@@ -77,6 +77,8 @@ const void *elacp_get_raw_data(ElaCP *cp);
 
 size_t elacp_get_raw_data_length(ElaCP *cp);
 
+const char *elacp_get_bundle(ElaCP *cp);
+
 const char *elacp_get_reason(ElaCP *cp);
 
 void elacp_set_name(ElaCP *cp, const char *name);
@@ -102,6 +104,8 @@ void elacp_set_totalsz(ElaCP *cp, size_t totalsz);
 void elacp_set_status(ElaCP *cp, int status);
 
 void elacp_set_raw_data(ElaCP *cp, const void *data, size_t len);
+
+void elacp_set_bundle(ElaCP *cp, const char *bundle);
 
 void elacp_set_reason(ElaCP *cp, const char *reason);
 

--- a/src/carrier/tassemblies.h
+++ b/src/carrier/tassemblies.h
@@ -20,8 +20,8 @@
  * SOFTWARE.
  */
 
-#ifndef __tassemblies_H__
-#define __tassemblies_H__
+#ifndef __TASSEMBLIES_H__
+#define __TASSEMBLIES_H__
 
 #include <string.h>
 #include <rc_mem.h>
@@ -32,10 +32,11 @@ typedef struct TransactedAssembly {
     char ext[ELA_MAX_EXTENSION_NAME_LEN + 1];
     char friendid[ELA_MAX_ID_LEN + 1];
     int64_t tid;
+    char *bundle;
+    char *reason;
     uint8_t *data;
     size_t  data_len;
     size_t  data_off;
-    bool    reason_parsed; // for response invitation.
     struct timeval expire_time;
     hash_entry_t he;
 } TransactedAssembly;
@@ -122,4 +123,4 @@ int tassemblies_iterator_remove(hashtable_iterator_t *iterator)
     return hashtable_iterator_remove(iterator);
 }
 
-#endif /* __tassemblies_H__ */
+#endif /* __TASSEMBLIES_H__ */

--- a/src/carrier/tcallbacks.h
+++ b/src/carrier/tcallbacks.h
@@ -37,6 +37,7 @@ typedef struct TransactedCallback {
     void *callback_func;
     void *callback_context;
     struct timeval expire_time;
+    char *bundle;
 } TransactedCallback;
 
 static

--- a/src/session/ela_session.h
+++ b/src/session/ela_session.h
@@ -62,8 +62,6 @@ extern "C" {
 
 #define ELA_MAX_USER_DATA_LEN   2048
 
-#define ELA_MAX_BUNDLE_LEN      128
-
 typedef struct ElaSession ElaSession;
 
 /**

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -69,7 +69,7 @@ typedef struct IceTransportOptions {
 } IceTransportOptions;
 
 typedef void (*friend_invite_callback)(ElaCarrier *, const char *from,
-              const char *data, size_t len, void *context);
+              const char *bundle, const char *data, size_t len, void *context);
 
 struct ElaCarrier       {
     pthread_mutex_t         ext_mutex;

--- a/tests/api/carrier/friend_invite_assembly_test.c
+++ b/tests/api/carrier/friend_invite_assembly_test.c
@@ -38,6 +38,7 @@
 
 struct CarrierContextExtra {
     char *from;
+    char *bundle;
     char *reason;
     char *data;
     int len;
@@ -46,6 +47,7 @@ struct CarrierContextExtra {
 
 static CarrierContextExtra extra = {
     .from   = NULL,
+    .bundle = NULL,
     .reason = NULL,
     .data   = NULL,
     .len    = 0,
@@ -126,15 +128,16 @@ static TestContext test_context = {
     .context_reset = test_context_reset
 };
 
-static void friend_invite_response_cb(ElaCarrier *w, const char *from, int status,
-                                      const char *reason, const void *content, size_t len,
-                                      void *context)
+static void friend_invite_response_cb(ElaCarrier *w, const char *from, const char *bundle,
+                                      int status, const char *reason, const void *content,
+                                      size_t len, void *context)
 {
     CarrierContextExtra *extra = ((CarrierContext *)context)->extra;
 
     extra->from   = strdup(from);
+    extra->bundle = bundle ? strdup(bundle) : NULL;
     extra->status = status;
-    extra->reason = (status != 0) ? (reason  ? strdup(reason ) : NULL) : NULL;
+    extra->reason = (status != 0) ? strdup(reason) : NULL;
     extra->len    = (int)len;
     if (content && len > 0) {
         extra->data = calloc(1, len);
@@ -146,14 +149,17 @@ static void friend_invite_response_cb(ElaCarrier *w, const char *from, int statu
     wakeup(context);
 }
 
-static void test_friend_invite_assembly_confirm(int hello_len)
+static void test_friend_invite_assembly_confirm(int hello_len, const char *bundle)
 {
     CarrierContext *wctxt = test_context.carrier;
     CarrierContextExtra *extra = wctxt->extra;
     char userid[ELA_MAX_ID_LEN + 1];
-    char *hello = alloca(hello_len);
+    char *hello = calloc(1, hello_len);
     int rc;
     bool is_wakeup;
+
+    if (!hello)
+        return;
 
     test_context.context_reset(&test_context);
 
@@ -162,15 +168,23 @@ static void test_friend_invite_assembly_confirm(int hello_len)
     CU_ASSERT_TRUE_FATAL(ela_is_friend(wctxt->carrier, robotid));
 
     memset(hello, 'H', hello_len);
-    rc = ela_invite_friend(wctxt->carrier, robotid, hello, hello_len,
+    rc = ela_invite_friend(wctxt->carrier, robotid, bundle, hello, hello_len,
                            friend_invite_response_cb, wctxt);
-    CU_ASSERT_EQUAL_FATAL(rc, 0);
+    if (bundle && (strlen(bundle) == 0 || strlen(bundle) > ELA_MAX_BUNDLE_LEN)) {
+        CU_ASSERT_EQUAL(rc, -1);
+        CU_ASSERT_EQUAL(ela_get_error(), ELA_GENERAL_ERROR(ELAERR_INVALID_ARGS));
+        return;
+    } else {
+        CU_ASSERT_EQUAL_FATAL(rc, 0);
+    }
 
     char val[2][32] = {{0}, {0}};
-    rc = read_ack("%32s %32s", val[0], val[1]);
-    CU_ASSERT_EQUAL_FATAL(rc, 2);
+    int len = 0;
+    rc = read_ack("%32s %32s %d", val[0], val[1], &len);
+    CU_ASSERT_EQUAL_FATAL(rc, 3);
     CU_ASSERT_STRING_EQUAL(val[0], "data");
     CU_ASSERT_STRING_EQUAL(val[1], "bigdata");
+    CU_ASSERT_EQUAL_FATAL(len, hello_len);
 
     (void)ela_get_userid(wctxt->carrier, userid, sizeof(userid));
     rc = write_cmd("freplyinvite_bigdata %s confirm\n", userid);
@@ -181,43 +195,72 @@ static void test_friend_invite_assembly_confirm(int hello_len)
     CU_ASSERT_TRUE(is_wakeup);
     if (is_wakeup) {
         CU_ASSERT_NSTRING_EQUAL(extra->from, robotid, strlen(robotid));
+        if (bundle) {
+            CU_ASSERT_NSTRING_EQUAL(extra->bundle, bundle, strlen(bundle));
+        } else {
+            CU_ASSERT_PTR_NULL(extra->bundle);
+        }
         CU_ASSERT_EQUAL(extra->status, 0);
         CU_ASSERT_PTR_NULL(extra->reason);
         CU_ASSERT_TRUE(memcmp(extra->data, hello, hello_len) == 0);
         CU_ASSERT_EQUAL(extra->len, hello_len);
 
         FREE_ANYWAY(extra->from);
+        FREE_ANYWAY(extra->bundle);
         FREE_ANYWAY(extra->data);
     }
+    FREE_ANYWAY(hello);
 }
 
-static void test_friend_invite_assembly_confirm_1200(void)
+static void test_friend_invite_assembly_confirm_d1200_b0(void)
 {
-    test_friend_invite_assembly_confirm(1200);
+    test_friend_invite_assembly_confirm(1200, "");
 }
 
-static void test_friend_invite_assembly_confirm_1500(void)
+static void test_friend_invite_assembly_confirm_d1200_bnull(void)
 {
-    test_friend_invite_assembly_confirm(1500);
+    test_friend_invite_assembly_confirm(1200, NULL);
 }
 
-static void test_friend_invite_assembly_confirm_2550(void)
+static void test_friend_invite_assembly_confirm_d1200_b20(void)
 {
-    test_friend_invite_assembly_confirm(2550);
+    char bundle[20] = {0};
+    memset(bundle, 'B', sizeof(bundle) - 1);
+    test_friend_invite_assembly_confirm(1200, bundle);
 }
 
-static void test_friend_invite_assembly_confirm_maxlen(void)
+static void test_friend_invite_assembly_confirm_d1270_b20(void)
 {
-    test_friend_invite_assembly_confirm(ELA_MAX_INVITE_DATA_LEN);
+    char bundle[20] = {0};
+    memset(bundle, 'B', sizeof(bundle) - 1);
+    test_friend_invite_assembly_confirm(1270, bundle);
 }
 
-static void test_friend_invite_assembly_reject_base(int hello_len)
+static void test_friend_invite_assembly_confirm_d2550_b20(void)
+{
+    char bundle[20] = {0};
+    memset(bundle, 'B', sizeof(bundle) - 1);
+    test_friend_invite_assembly_confirm(2550, bundle);
+}
+
+static void test_friend_invite_assembly_confirm_d2550_bmaxlen(void)
+{
+    char bundle[ELA_MAX_BUNDLE_LEN + 1] = {0};
+    memset(bundle, 'B', sizeof(bundle) - 1);
+    test_friend_invite_assembly_confirm(2550, bundle);
+}
+
+static void test_friend_invite_assembly_confirm_dmaxlen_bnull(void)
+{
+    test_friend_invite_assembly_confirm(ELA_MAX_INVITE_DATA_LEN, NULL);
+}
+
+static void test_friend_invite_assembly_reject_base(const char *bundle, const char *reason)
 {
     CarrierContext *wctxt = test_context.carrier;
     CarrierContextExtra *extra = wctxt->extra;
     char userid[ELA_MAX_ID_LEN + 1];
-    char *hello = (char*)alloca(hello_len);
-    char *reason = "IDoNotKnowWhoYouAre!";
+    char *hello = "hello";
     int rc;
     bool is_wakup;
 
@@ -228,8 +271,7 @@ static void test_friend_invite_assembly_reject_base(int hello_len)
     CU_ASSERT_EQUAL_FATAL(rc, 0);
     CU_ASSERT_TRUE_FATAL(ela_is_friend(wctxt->carrier, robotid));
 
-    memset(hello, 'H', hello_len);
-    rc = ela_invite_friend(wctxt->carrier, robotid, hello, hello_len,
+    rc = ela_invite_friend(wctxt->carrier, robotid, bundle, hello, strlen(hello) + 1,
                            friend_invite_response_cb, wctxt);
     CU_ASSERT_EQUAL_FATAL(rc, 0);
 
@@ -237,7 +279,7 @@ static void test_friend_invite_assembly_reject_base(int hello_len)
     rc = read_ack("%32s %32s", val[0], val[1]);
     CU_ASSERT_EQUAL_FATAL(rc, 2);
     CU_ASSERT_STRING_EQUAL(val[0], "data");
-    CU_ASSERT_STRING_EQUAL(val[1], "bigdata");
+    CU_ASSERT_STRING_EQUAL(val[1], hello);
 
     (void)ela_get_userid(wctxt->carrier, userid, sizeof(userid));
     rc = write_cmd("freplyinvite_bigdata %s refuse %s\n", userid, reason);
@@ -249,33 +291,47 @@ static void test_friend_invite_assembly_reject_base(int hello_len)
     if (is_wakup) {
         CU_ASSERT_NSTRING_EQUAL(extra->from, robotid, strlen(robotid));
         CU_ASSERT(extra->status != 0);
-        CU_ASSERT_STRING_EQUAL(extra->reason, reason);
-        CU_ASSERT_TRUE(memcmp(extra->data, hello, hello_len) == 0);
-        CU_ASSERT_EQUAL(extra->len, hello_len);
+        if (reason) {
+            CU_ASSERT_NSTRING_EQUAL(extra->reason, reason, strlen(reason));
+        } else {
+            CU_ASSERT_STRING_EQUAL(extra->reason, "(null)");
+        }
 
         FREE_ANYWAY(extra->from);
         FREE_ANYWAY(extra->reason);
     }
 }
 
-static void test_friend_invite_assembly_reject_1200(void)
+static void test_friend_invite_assembly_reject_b20_r20(void)
 {
-    test_friend_invite_assembly_reject_base(1200);
+    char bundle[20] = {0};
+    char reason[20] = {0};
+    memset(bundle, 'B', sizeof(bundle) - 1);
+    memset(reason, 'R', sizeof(reason) - 1);
+    test_friend_invite_assembly_reject_base(bundle, reason);
 }
 
-static void test_friend_invite_assembly_reject_1270(void)
+static void test_friend_invite_assembly_reject_bnull_r20(void)
 {
-    test_friend_invite_assembly_reject_base(1270);
+    char reason[20] = {0};
+    memset(reason, 'B', sizeof(reason) - 1);
+    test_friend_invite_assembly_reject_base(NULL, reason);
 }
 
-static void test_friend_invite_assembly_reject_2530(void)
+static void test_friend_invite_assembly_reject_bnull_rmaxlen(void)
 {
-    test_friend_invite_assembly_reject_base(2530);
+    char reason[ELA_MAX_INVITE_REPLY_REASON_LEN + 1] = {0};
+    memset(reason, 'R', sizeof(reason) - 1);
+    test_friend_invite_assembly_reject_base(NULL, reason);
 }
 
-static void test_friend_invite_assembly_reject_2550(void)
+static void test_friend_invite_assembly_reject_bmaxlen_rmaxlen(void)
 {
-    test_friend_invite_assembly_reject_base(2550);
+    char bundle[ELA_MAX_BUNDLE_LEN + 1] = {0};
+    char reason[ELA_MAX_INVITE_REPLY_REASON_LEN + 1] = {0};
+    memset(bundle, 'B', sizeof(bundle) - 1);
+    memset(reason, 'R', sizeof(reason) - 1);
+    test_friend_invite_assembly_reject_base(bundle, reason);
 }
 
 static void test_friend_invite_with_overlong_data(void)
@@ -291,22 +347,25 @@ static void test_friend_invite_with_overlong_data(void)
     CU_ASSERT_TRUE_FATAL(ela_is_friend(wctxt->carrier, robotid));
 
     memset(data, 'T', ELA_MAX_INVITE_DATA_LEN);
-    rc = ela_invite_friend(wctxt->carrier, robotid, data, sizeof(data),
+    rc = ela_invite_friend(wctxt->carrier, NULL, robotid, data, sizeof(data),
                            friend_invite_response_cb, wctxt);
     CU_ASSERT_EQUAL(rc, -1);
     CU_ASSERT_EQUAL(ela_get_error(), ELA_GENERAL_ERROR(ELAERR_INVALID_ARGS));
 }
 
 static CU_TestInfo cases[] = {
-    { "test_friend_invite_assembly_confirm_1200",  test_friend_invite_assembly_confirm_1200 },
-    { "test_friend_invite_assembly_confirm_1500",  test_friend_invite_assembly_confirm_1500 },
-    { "test_friend_invite_assembly_confirm_2550",  test_friend_invite_assembly_confirm_2550 },
-    { "test_friend_invite_assembly_confirm_maxlen",test_friend_invite_assembly_confirm_maxlen },
-    { "test_friend_invite_assembly_reject_1200", test_friend_invite_assembly_reject_1200 },
-    { "test_friend_invite_assembly_reject_1270", test_friend_invite_assembly_reject_1270 },
-    { "test_friend_invite_assembly_reject_2530", test_friend_invite_assembly_reject_2530 },
-    { "test_friend_invite_assembly_reject_2550", test_friend_invite_assembly_reject_2550 },
-    { "test_friend_invite_with_overlong_data",   test_friend_invite_with_overlong_data },
+    { "test_friend_invite_assembly_confirm_d1200_b0",       test_friend_invite_assembly_confirm_d1200_b0 },
+    { "test_friend_invite_assembly_confirm_d1200_bnull",    test_friend_invite_assembly_confirm_d1200_bnull },
+    { "test_friend_invite_assembly_confirm_d1200_b20",      test_friend_invite_assembly_confirm_d1200_b20},
+    { "test_friend_invite_assembly_confirm_d1270_b20",      test_friend_invite_assembly_confirm_d1270_b20},
+    { "test_friend_invite_assembly_confirm_d2550_b20",      test_friend_invite_assembly_confirm_d2550_b20},
+    { "test_friend_invite_assembly_confirm_d2550_bmaxlen",  test_friend_invite_assembly_confirm_d2550_bmaxlen},
+    { "test_friend_invite_assembly_confirm_dmaxlen_bnull",  test_friend_invite_assembly_confirm_dmaxlen_bnull },
+    { "test_friend_invite_assembly_reject_b20_r20",         test_friend_invite_assembly_reject_b20_r20 },
+    { "test_friend_invite_assembly_reject_bnull_r20",       test_friend_invite_assembly_reject_bnull_r20 },
+    { "test_friend_invite_assembly_reject_bnull_rmaxlen",   test_friend_invite_assembly_reject_bnull_rmaxlen },
+    { "test_friend_invite_assembly_reject_bmaxlen_rmaxlen", test_friend_invite_assembly_reject_bmaxlen_rmaxlen},
+    { "test_friend_invite_with_overlong_data",              test_friend_invite_with_overlong_data },
     { NULL, NULL }
 };
 

--- a/tests/api/carrier/friend_invite_test.c
+++ b/tests/api/carrier/friend_invite_test.c
@@ -121,9 +121,9 @@ static TestContext test_context = {
     .context_reset = test_context_reset
 };
 
-static void friend_invite_response_cb(ElaCarrier *w, const char *from, int status,
-                                      const char *reason, const void *content, size_t len,
-                                      void *context)
+static void friend_invite_response_cb(ElaCarrier *w, const char *from, const char *bundle,
+                                      int status, const char *reason, const void *content,
+                                      size_t len, void *context)
 {
     CarrierContextExtra *extra = ((CarrierContext *)context)->extra;
 
@@ -152,7 +152,7 @@ static void test_friend_invite_confirm(void)
     CU_ASSERT_TRUE_FATAL(ela_is_friend(wctxt->carrier, robotid));
 
     const char* hello = "hello";
-    rc = ela_invite_friend(wctxt->carrier, robotid, hello,
+    rc = ela_invite_friend(wctxt->carrier, robotid, NULL, hello,
                                strlen(hello) + 1,
                                friend_invite_response_cb, wctxt);
     CU_ASSERT_EQUAL_FATAL(rc, 0);
@@ -202,7 +202,7 @@ static void test_friend_invite_reject(void)
     CU_ASSERT_TRUE_FATAL(ela_is_friend(wctxt->carrier, robotid));
 
     const char* hello = "hello";
-    rc = ela_invite_friend(wctxt->carrier, robotid, hello, strlen(hello) + 1,
+    rc = ela_invite_friend(wctxt->carrier, robotid, NULL, hello, strlen(hello) + 1,
                                friend_invite_response_cb, wctxt);
     CU_ASSERT_EQUAL_FATAL(rc, 0);
 
@@ -246,7 +246,7 @@ static void test_friend_invite_stranger(void)
     CU_ASSERT_EQUAL_FATAL(rc, 0);
     CU_ASSERT_FALSE_FATAL(ela_is_friend(wctxt->carrier, robotid));
 
-    rc = ela_invite_friend(wctxt->carrier, robotid, hello, strlen(hello) + 1,
+    rc = ela_invite_friend(wctxt->carrier, robotid, NULL, hello, strlen(hello) + 1,
                                friend_invite_response_cb, wctxt);
     CU_ASSERT_EQUAL(rc, -1);
     CU_ASSERT_EQUAL(ela_get_error(), ELA_GENERAL_ERROR(ELAERR_NOT_EXIST));
@@ -260,7 +260,7 @@ static void test_friend_invite_self(void)
     int rc;
 
     (void)ela_get_userid(wctxt->carrier, userid, sizeof(userid));
-    rc = ela_invite_friend(wctxt->carrier, userid, hello, strlen(hello) + 1,
+    rc = ela_invite_friend(wctxt->carrier, userid, NULL, hello, strlen(hello) + 1,
                                friend_invite_response_cb, wctxt);
     CU_ASSERT_EQUAL(rc, -1);
     CU_ASSERT_EQUAL(ela_get_error(), ELA_GENERAL_ERROR(ELAERR_NOT_EXIST));

--- a/tests/api/test_helper.c
+++ b/tests/api/test_helper.c
@@ -197,13 +197,14 @@ static void carrier_friend_message_cb(ElaCarrier *w, const char *from,
 }
 
 static void carrier_friend_invite_cb(ElaCarrier *w, const char *from,
+                                     const char *bundle,
                                      const void *data, size_t len,
                                      void *context)
 {
     ElaCallbacks *cbs = ((CarrierContext*)context)->cbs;
 
     if (cbs && cbs->friend_invite)
-        cbs->friend_invite(w, from, data, len, context);
+        cbs->friend_invite(w, from, bundle, data, len, context);
 }
 
 static void carrier_peer_list_changed_cb(ElaCarrier *w,

--- a/tests/robot/robot.c
+++ b/tests/robot/robot.c
@@ -47,6 +47,7 @@
 
 struct CarrierContextExtra {
     char userid[ELA_MAX_ID_LEN + 1];
+    char *bundle;
     char *data;
     int len;
     char gcookie[128];
@@ -57,6 +58,7 @@ struct CarrierContextExtra {
 
 static CarrierContextExtra extra = {
     .userid = {0},
+    .bundle = NULL,
     .data   = NULL,
     .len    = 0,
     .gcookie = {0},
@@ -230,16 +232,20 @@ static void friend_message_cb(ElaCarrier *w, const char *from,
     write_ack("%s\n", msg);
 }
 
-static void friend_invite_cb(ElaCarrier *w, const char *from,
+static void friend_invite_cb(ElaCarrier *w, const char *from, const char *bundle,
                              const void *data, size_t len, void *context)
 {
+    CarrierContextExtra *extra = ((TestContext*)context)->carrier->extra;
+
     vlogD("Recevied friend invite from %s", from);
     vlogD(" data: %s", (const char *)data);
+
+    if (bundle)
+        extra->bundle = strdup(bundle);
 
     if (len <= ELA_MAX_APP_MESSAGE_LEN)
         write_ack("data %s\n", data);
     else {
-        CarrierContextExtra *extra = ((TestContext*)context)->carrier->extra;
         extra->data = (char*)malloc(len);
         memcpy(extra->data, data, len);
         extra->len = (int)len;


### PR DESCRIPTION
Check and add two more test cases.

Remove the optional bundle from sessoin-related APIs.

Remove the infinite loop when invoking ela_reply_friend_invite() with data set to NULL and len set to a positive integer.