### PR TITLE
fix group bugs

### DIFF
--- a/src/carrier/dht/dht.c
+++ b/src/carrier/dht/dht.c
@@ -683,7 +683,7 @@ void notify_conference_title_cb(Tox *tox, uint32_t conference_number,
     DHTCallbacks *cbs = (DHTCallbacks *)context;
 
     cbs->notify_group_title(conference_number, peer_number,
-                            (const char *)title, cbs->context);
+                            title, length, cbs->context);
 }
 
 static
@@ -694,7 +694,7 @@ void notify_conference_peer_name_cb(Tox *tox, uint32_t conference_number,
     DHTCallbacks *cbs = (DHTCallbacks *)context;
 
     cbs->notify_group_peer_name(conference_number, peer_number,
-                                (const char *)name, cbs->context);
+                                name, length, cbs->context);
 }
 
 static
@@ -1018,7 +1018,28 @@ void dht_iterate(DHT *dht, void *context)
     tox_iterate(tox, context);
 }
 
-int dht_self_set_name(DHT *dht, const char *name)
+int dht_self_get_name(DHT *dht, uint8_t *name, size_t length)
+{
+    Tox *tox = dht->tox;
+    TOX_ERR_SET_INFO error;
+    bool success;
+    size_t name_len;
+
+    assert(tox);
+    assert(name);
+    assert(length);
+
+    name_len = tox_self_get_name_size(tox);
+    if (name_len > length) {
+        assert(0);
+        return ELA_DHT_ERROR(ELAERR_BUFFER_TOO_SMALL);
+    }
+
+    tox_self_get_name(tox, (uint8_t *)name);
+    return name_len;
+}
+
+int dht_self_set_name(DHT *dht, const uint8_t *name, size_t length)
 {
     Tox *tox = dht->tox;
     TOX_ERR_SET_INFO error;
@@ -1027,8 +1048,7 @@ int dht_self_set_name(DHT *dht, const char *name)
     assert(tox);
     assert(name);
 
-    success = tox_self_set_name(tox, (const uint8_t *)name,
-                                strlen(name) + 1, &error);
+    success = tox_self_set_name(tox, name, length, &error);
     if (!success) {
         vlogE("DHT: set self name error (%d).", error);
         return __dht_set_info_error(error);
@@ -1314,7 +1334,7 @@ int dht_group_send_message(DHT *dht, uint32_t group_number,
     return 0;
 }
 
-int dht_group_get_title(DHT *dht, uint32_t group_number, char *title,
+int dht_group_get_title(DHT *dht, uint32_t group_number, uint8_t *title,
                         size_t length)
 {
     Tox *tox = dht->tox;
@@ -1327,7 +1347,9 @@ int dht_group_get_title(DHT *dht, uint32_t group_number, char *title,
     assert(length > 0);
 
     len = tox_conference_get_title_size(tox, group_number, &error);
-    if (error != TOX_ERR_CONFERENCE_TITLE_OK) {
+    if (error == TOX_ERR_CONFERENCE_TITLE_INVALID_LENGTH)
+        return 0;
+    else if (error != TOX_ERR_CONFERENCE_TITLE_OK) {
         vlogE("DHT: Get title size of group %lu error (%d)", group_number,
               error);
         return __dht_group_title_error(error);
@@ -1342,10 +1364,11 @@ int dht_group_get_title(DHT *dht, uint32_t group_number, char *title,
         return __dht_group_title_error(error);
     }
 
-    return 0;
+    return len;
 }
 
-int dht_group_set_title(DHT *dht, uint32_t group_number, const char *title)
+int dht_group_set_title(DHT *dht, uint32_t group_number,
+                        const uint8_t *title, size_t length)
 {
     Tox *tox = dht->tox;
     TOX_ERR_CONFERENCE_TITLE error;
@@ -1354,8 +1377,7 @@ int dht_group_set_title(DHT *dht, uint32_t group_number, const char *title)
     assert(group_number != UINT32_MAX);
     assert(title);
 
-    tox_conference_set_title(tox, group_number, (const uint8_t *)title,
-                             strlen(title) + 1, &error);
+    tox_conference_set_title(tox, group_number, title, length, &error);
     if (error != TOX_ERR_CONFERENCE_TITLE_OK) {
         vlogE("DHT: Get title of group %lu error (%d)", group_number, error);
         return __dht_group_title_error(error);
@@ -1403,6 +1425,9 @@ int dht_group_get_peer_name(DHT *dht, uint32_t group_number, uint32_t peer_numbe
         return __dht_group_peer_query_error(error);
     }
 
+    if (!len)
+        return 0;
+
     if (len > length)
         return ELA_DHT_ERROR(ELAERR_BUFFER_TOO_SMALL);
 
@@ -1414,7 +1439,7 @@ int dht_group_get_peer_name(DHT *dht, uint32_t group_number, uint32_t peer_numbe
         return __dht_group_peer_query_error(error);
     }
 
-    return 0;
+    return len;
 }
 
 int dht_group_get_peer_public_key(DHT *dht, uint32_t group_number,

--- a/src/carrier/dht/dht.h
+++ b/src/carrier/dht/dht.h
@@ -70,7 +70,9 @@ int dht_iteration_idle(DHT *dht);
 
 void dht_iterate(DHT *dht, void *context);
 
-int dht_self_set_name(DHT *dht, const char *name);
+int dht_self_get_name(DHT *dht, uint8_t *name, size_t length);
+
+int dht_self_set_name(DHT *dht, const uint8_t *name, size_t length);
 
 int dht_self_set_desc(DHT *dht, uint8_t *status_msg, size_t length);
 
@@ -110,9 +112,11 @@ int dht_group_join(DHT *dht, uint32_t friend_number, const uint8_t *cookie,
 int dht_group_send_message(DHT *dht, uint32_t group_number,
                            const uint8_t *msg, size_t length);
 
-int dht_group_get_title(DHT *dht, uint32_t group_number, char *title, size_t length);
+int dht_group_get_title(DHT *dht, uint32_t group_number, uint8_t *title,
+                        size_t length);
 
-int dht_group_set_title(DHT *dht, uint32_t group_number, const char *title);
+int dht_group_set_title(DHT *dht, uint32_t group_number, const uint8_t *title,
+                        size_t length);
 
 int dht_group_get_peer_name(DHT *dht, uint32_t group_number, uint32_t peer_number,
                             char *name, size_t length);

--- a/src/carrier/dht/dht_callbacks.h
+++ b/src/carrier/dht/dht_callbacks.h
@@ -58,10 +58,12 @@ struct DHTCallbacks {
                                  const uint8_t *msg, size_t len, void *context);
 
     void (*notify_group_title)(uint32_t gnum, uint32_t pnum,
-                               const char *title, void *context);
+                               const uint8_t *title, size_t length,
+                               void *context);
 
     void (*notify_group_peer_name)(uint32_t gnum, uint32_t pnum,
-                                   const char *name, void *context);
+                                   const uint8_t *name, size_t length,
+                                   void *context);
 
     void (*notify_group_peer_list_changed)(uint32_t gnum, void *context);
 };

--- a/src/carrier/ela_carrier.c
+++ b/src/carrier/ela_carrier.c
@@ -351,6 +351,8 @@ static void get_self_info_cb(const uint8_t *address, const uint8_t *public_key,
     ElaCarrier *w = (ElaCarrier *)context;
     ElaUserInfo *ui = &w->me;
     size_t text_len;
+    char dht_name[ELA_MAX_USER_NAME_LEN + 1];
+    int name_len;
 
     memcpy(w->address, address, DHT_ADDRESS_SIZE);
     memcpy(w->public_key, public_key, DHT_PUBLIC_KEY_SIZE);
@@ -366,6 +368,17 @@ static void get_self_info_cb(const uint8_t *address, const uint8_t *public_key,
         unpack_user_desc(desc, desc_len, ui, NULL);
     else
         fill_empty_user_desc(w);
+
+    name_len = dht_self_get_name(&w->dht, (uint8_t *)dht_name,
+                                 sizeof(dht_name));
+    if (name_len < 0)
+        return;
+
+    if ((name_len <= 1 && !strlen(w->me.name)) ||
+        (name_len > 1 && !strcmp(dht_name, w->me.name)))
+        return;
+
+    dht_self_set_name(&w->dht, (uint8_t *)w->me.name, strlen(w->me.name) + 1);
 }
 
 static bool friends_iterate_cb(uint32_t friend_number,
@@ -2078,7 +2091,7 @@ void notify_group_message_cb(uint32_t group_number, uint32_t peer_number,
 
 static
 void notify_group_title_cb(uint32_t group_number, uint32_t peer_number,
-                           const char *title, void *user_data)
+                           const uint8_t *title, size_t length, void *user_data)
 {
     ElaCarrier *w = (ElaCarrier *)user_data;
     char groupid[ELA_MAX_ID_LEN + 1];
@@ -2107,12 +2120,15 @@ void notify_group_title_cb(uint32_t group_number, uint32_t peer_number,
 
     if (w->callbacks.group_callbacks.group_title)
         w->callbacks.group_callbacks.group_title(w, groupid, peerid,
-                                                title, w->context);
+                                                length ?
+                                                (const char *)title : "",
+                                                w->context);
 }
 
 static
 void notify_group_peer_name_cb(uint32_t group_number, uint32_t peer_number,
-                               const char *name, void *user_data)
+                               const uint8_t *name, size_t length,
+                               void *user_data)
 {
     ElaCarrier *w = (ElaCarrier *)user_data;
     char groupid[ELA_MAX_ID_LEN + 1];
@@ -2121,7 +2137,7 @@ void notify_group_peer_name_cb(uint32_t group_number, uint32_t peer_number,
 
     rc = get_groupid_by_number(w, group_number, groupid, sizeof(groupid));
     if (rc < 0) {
-        vlogE("Carrier: Unknown group number %u, group titile change event "
+        vlogE("Carrier: Unknown group number %u, group peer name change event "
               "dropped.", group_number);
         return;
     }
@@ -2129,13 +2145,14 @@ void notify_group_peer_name_cb(uint32_t group_number, uint32_t peer_number,
     rc = get_peerid_by_number(w, group_number, peer_number, peerid,
                               sizeof(peerid));
     if (rc < 0) {
-        vlogE("Carrier: Unknown peer number %u, group titile change event "
+        vlogE("Carrier: Unknown peer number %u, group peer name change event "
               "dropped.", peer_number);
         return;
     }
 
     if (w->callbacks.group_callbacks.peer_name)
-        w->callbacks.group_callbacks.peer_name(w, groupid, peerid, name,
+        w->callbacks.group_callbacks.peer_name(w, groupid, peerid,
+                                               length ? (char *)name : "",
                                                w->context);
 }
 
@@ -2367,7 +2384,8 @@ int ela_set_self_info(ElaCarrier *w, const ElaUserInfo *info)
 
     if (did_changed) {
         if (strcmp(info->name, w->me.name)) {
-            int rc = dht_self_set_name(&w->dht, info->name);
+            int rc = dht_self_set_name(&w->dht, (uint8_t *)info->name,
+                                       strlen(info->name) + 1);
             if (rc) {
                 elacp_free(cp);
                 ela_set_error(rc);
@@ -3490,11 +3508,12 @@ int ela_group_get_title(ElaCarrier *w, const char *groupid, char *title,
         return  -1;
     }
 
-    rc = dht_group_get_title(&w->dht, group_number, title, length);
+    rc = dht_group_get_title(&w->dht, group_number, (uint8_t *)title, length);
     if (rc < 0) {
         ela_set_error(rc);
         return -1;
-    }
+    } else if (!rc)
+        title[0] = '\0';
 
     return 0;
 }
@@ -3502,6 +3521,7 @@ int ela_group_get_title(ElaCarrier *w, const char *groupid, char *title,
 int ela_group_set_title(ElaCarrier *w, const char *groupid, const char *title)
 {
     uint32_t group_number;
+    char tbuf[ELA_MAX_GROUP_TITLE_LEN + 1];
     int rc;
 
     if (!w || !groupid || !*groupid || !title || !*title ||
@@ -3521,7 +3541,18 @@ int ela_group_set_title(ElaCarrier *w, const char *groupid, const char *title)
         return -1;
     }
 
-    rc = dht_group_set_title(&w->dht, group_number, title);
+    rc = dht_group_get_title(&w->dht, group_number,
+                             (uint8_t *)tbuf, sizeof(tbuf));
+    if (rc < 0) {
+        ela_set_error(rc);
+        return -1;
+    } else if ((rc <= 1 && !strlen(title)) ||
+               (rc > 1 && !strcmp(tbuf, title))) {
+        return 0;
+    }
+
+    rc = dht_group_set_title(&w->dht, group_number,
+                             (uint8_t *)title, strlen(title) + 1);
     if (rc < 0) {
         ela_set_error(rc);
         return -1;
@@ -3573,7 +3604,8 @@ int ela_group_get_peers(ElaCarrier *w, const char *groupid,
             vlogW("Carrier: Get peer %lu name from group:%lu error.",
                   i, group_number);
             continue;
-        }
+        } else if (!rc)
+            peer.name[0] = '\0';
 
         rc = dht_group_get_peer_public_key(&w->dht, group_number, i, public_key);
         if (rc < 0) {
@@ -3662,7 +3694,8 @@ int ela_group_get_peer(ElaCarrier *w, const char *groupid,
               group_number);
         ela_set_error(rc);
         return -1;
-    }
+    } else if (!rc)
+        peer->name[0] = '\0';
 
     strcpy(peer->userid, peerid);
     return 0;

--- a/src/carrier/ela_carrier.h
+++ b/src/carrier/ela_carrier.h
@@ -434,7 +434,7 @@ typedef struct ElaFriendInfo {
 typedef struct ElaGroupPeer {
     /**
      * \~English
-     * Peer's name.
+     * Peer's Carrier user name.
      */
     char name[ELA_MAX_USER_NAME_LEN + 1];
 


### PR DESCRIPTION
1. tox name synchronizes with carrier name
2. if group title empty, ela_group_get_title() returns empty string rather than error