### PR TITLE
bugfix for compilation on RaspberryPi platform (bugfix for issue #173)

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,13 +360,13 @@ Generate the Makefile in the current directory:
 *Note: Please see custom options below.*
 
 ```shell
-$ cmake ../..
+$ cmake -DBUILD_ON_RPI=ON ../..
 ```
 
 ***
 Optional (Generate the Makefile): To be able to build a distribution with a specific build type **Debug/Release**, as well as with customized install location of distributions, run the following commands:
 ```shell
-$ cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=YOUR-INSTALL-PATH ../..
+$ cmake -DBUILD_ON_RPI=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=YOUR-INSTALL-PATH ../..
 ```
 ***
 

--- a/deps/pjsip/CMakeLists.txt
+++ b/deps/pjsip/CMakeLists.txt
@@ -138,7 +138,11 @@ if(UNIX)
             # set library suffix name for raspberry PI target.
             # only support for armv7l. (TODO: update)
             # only support with Linux host.
-            set(PJLIB_SUFFIX "arm-unknown-linux-gnueabihf")
+            set(PJLIB_SUFFIX "armv7l-unknown-linux-gnueabihf")
+        elseif(BUILD_ON_RPI)
+            # set library suffix name for raspberry PI target
+            # only support for compilation on raspberry PI platform.
+            set(PJLIB_SUFFIX "armv7l-unknown-linux-gnueabihf")
         else()
             # set library name for Linux target itself.
             set(PJLIB_SUFFIX "x86_64-unknown-linux-gnu")


### PR DESCRIPTION
Use option 'BUILD_ON_RPI' to specify compilation on RaspberryPI, so it can rename or make a linkage a right pj libraries with specified suffix. 