### PR TITLE
fix android armeabi-v7a compiling where NDK resolves _Unwind* symbols…

### DIFF
--- a/cmake/ExternalCMakeArgs.cmake
+++ b/cmake/ExternalCMakeArgs.cmake
@@ -29,8 +29,9 @@ endif()
 if(ANDROID)
     set(XDK_SYSROOT "${CMAKE_BINARY_DIR}/.android_toolchain/sysroot")
     set(CMAKE_ARGS_INIT ${CMAKE_ARGS_INIT}
-        -DANDROID_NDK_HOME=${CMAKE_ANDROID_NDK}
-        -DANDROID_ABI=${ANDROID_ABI})
+        "-DANDROID_NDK_HOME=${CMAKE_ANDROID_NDK}"
+        "-DANDROID_ABI=${ANDROID_ABI}"
+        -DCMAKE_SHARED_LINKER_FLAGS=-Wl,--exclude-libs,ALL)
 endif()
 
 if(RASPBERRYPI)

--- a/cmake/ExternalConfigureArgs.cmake
+++ b/cmake/ExternalConfigureArgs.cmake
@@ -29,7 +29,7 @@ if(${CMAKE_CROSSCOMPILING})
 
         set(XDK_C_FLAGS "${CMAKE_C_FLAGS_INIT} ${CMAKE_C_FLAGS}")
         set(XDK_CXX_FLAGS "${XDK_C_FLAGS} -fexceptions")
-        set(XDK_C_LINK_FLAGS "${XDK_C_FLAGS}")
+        set(XDK_C_LINK_FLAGS "${XDK_C_FLAGS} -Wl,--exclude-libs,ALL")
     endif()
 
     if(IOS)

--- a/deps/Elastos.NET.Hive.Native.SDK/CMakeLists.txt
+++ b/deps/Elastos.NET.Hive.Native.SDK/CMakeLists.txt
@@ -32,12 +32,17 @@ set(HIVE_DEPS
     hive-api++
     curl)
 
-set(LIBC++_SHARED
-    ${CMAKE_ANDROID_NDK}/sources/cxx-stl/llvm-libc++/libs/${CMAKE_ANDROID_ARCH_ABI}/libc++_shared.so)
 
 if(WIN32)
     set(HIVE_DEPS ${HIVE_DEPS} zlib1 ws2_32)
 elseif(ANDROID)
+    set(LIBC++_SHARED
+        ${CMAKE_ANDROID_NDK}/sources/cxx-stl/llvm-libc++/libs/${CMAKE_ANDROID_ARCH_ABI}/libc++_shared.so)
+    if(${ANDROID_ABI} STREQUAL armeabi-v7a)
+        set(LIBUNWIND_STATIC
+            ${CMAKE_ANDROID_NDK}/sources/cxx-stl/llvm-libc++/libs/${CMAKE_ANDROID_ARCH_ABI}/libunwind.a)
+        set(HIVE_DEPS ${HIVE_DEPS} ${LIBUNWIND_STATIC})
+    endif()
     set(HIVE_DEPS ${HIVE_DEPS} z ${LIBC++_SHARED})
 else()
     set(HIVE_DEPS ${HIVE_DEPS} z stdc++)


### PR DESCRIPTION
… to wrong library by hiding extraneous symbols brought with embedded archives in shared libraries