### PR TITLE
Open bulkmsg offline testcase.

### DIFF
--- a/apps/shell/shell.c
+++ b/apps/shell/shell.c
@@ -961,7 +961,7 @@ static void send_receipt_message(ElaCarrier *w, int argc, char *argv[])
 static void send_receipt_bulkmessage(ElaCarrier *w, int argc, char *argv[])
 {
     int rc;
-    int datalen = 2048;
+    int datalen = ELA_MAX_APP_BULKMSG_LEN;
     char *data;
     int idx;
 

--- a/src/carrier/express.c
+++ b/src/carrier/express.c
@@ -109,7 +109,7 @@ typedef struct {
 static const int  EXP_CURLCODE_MASK    = 0x00001000;
 static const int  EXP_HTTP_MAGICNUM    = 0xCA6EE595;
 static const int  EXP_HTTP_MAGICSIZE   = 4;
-static const int  EXP_HTTP_REQ_TIMEOUT     = 30 * 1000; // ms
+static const int  EXP_HTTP_REQ_TIMEOUT     = 60 * 1000; // ms
 static const int  EXP_HTTP_HEAD_TIMEOUT     = 5 * 1000; // ms
 #define  EXP_HTTP_URL_MAXSIZE 1024
 

--- a/tests/apitests/api/carrier/friend_message_with_receipt_test.c
+++ b/tests/apitests/api/carrier/friend_message_with_receipt_test.c
@@ -317,7 +317,7 @@ static void test_send_offline_bulkmsg_with_receipt(void)
 {
     CarrierContext *wctxt = test_context.carrier;
     CarrierContextExtra *extra = wctxt->extra;
-    size_t bulksz = 1*1024*1024;
+    size_t bulksz = ELA_MAX_APP_BULKMSG_LEN;
     char *bulkmsg;
     int64_t msgid = 0;
     int size;
@@ -447,7 +447,7 @@ static CU_TestInfo cases[] = {
     { "test_send_message_with_receipt", test_send_message_with_receipt },
     { "test_send_bulkmsg_with_receipt", test_send_bulkmsg_with_receipt },
     { "test_send_offmsg_with_receipt",  test_send_offmsg_with_receipt  },
-    //{ "test_send_offline_bulkmsg_with_receipt", test_send_offline_bulkmsg_with_receipt },
+    { "test_send_offline_bulkmsg_with_receipt", test_send_offline_bulkmsg_with_receipt },
     { "test_send_msg_with_receipt_in_edge_case", test_send_msg_with_receipt_in_edge_case },
     {NULL, NULL }
 };


### PR DESCRIPTION
1. Update Express timeout to 60 seconds.
2. Open bulkmsg offline testcase.